### PR TITLE
Account Request Form: Remove `required` on NPI

### DIFF
--- a/_includes/forms/ordering-provider.html
+++ b/_includes/forms/ordering-provider.html
@@ -5,8 +5,8 @@
   <input class="usa-input" id="op-first-name" name="op-first-name" type="text" spellcheck="false">
   <label class="usa-label" for="op-last-name">Last name</label>
   <input class="usa-input" id="op-last-name" name="op-last-name" type="text" spellcheck="false">
-  <label class="usa-label" for="npi">National Provider Identifier (NPI) {% include required.html %}</label>
-  <input class="usa-input" id="npi" name="npi" type="text" required>
+  <label class="usa-label" for="npi">National Provider Identifier (NPI)</label>
+  <input class="usa-input" id="npi" name="npi" type="text">
   <label class="usa-label" for="op-phone-number">Phone number</label>
   <input class="usa-input" id="op-phone-number" name="op-phone-number" type="tel">
   <fieldset class="usa-fieldset">


### PR DESCRIPTION
Turns out that NPI _can't_ be required on this form, bc North Dakota doesn't require NPIs from their providers