### PR TITLE
adjust property name for other browsers to match backend

### DIFF
--- a/_includes/forms/testing-facility-information.html
+++ b/_includes/forms/testing-facility-information.html
@@ -131,8 +131,8 @@
       <label class="usa-radio__label" for="other-facility">Other*</label>
     </div>
   </fieldset>
-  <label class="usa-label" for="other-facility-type">*Other facility</label>
-  <input class="usa-input" id="other-facility-type" name="other-facility" type="text">
+  <label class="usa-label" for="facility-type-other">*Other facility</label>
+  <input class="usa-input" id="facility-type-other" name="facility-type-other" type="text">
   <label class="usa-label" for="organization-name">What’s the name of your organization?  {% include required.html %}</label>
   <p class="usa-hint margin-top-1 font-body-2xs">If you have only one testing facility, then your organization name and facility name will be the same.</p>
   <input class="usa-input" id="organization-name" name="organization-name" type="text" spellcheck="false" required>

--- a/_includes/forms/testing-facility-information.html
+++ b/_includes/forms/testing-facility-information.html
@@ -252,8 +252,8 @@
       <label class="usa-checkbox__label" for="other-browser">Other*</label>
     </div>
   </fieldset>
-  <label class="usa-label" for="other-browser-type">*Other browser</label>
-  <input class="usa-input" id="other-browser-type" name="other-browser" type="text">
+  <label class="usa-label" for="browsers-other">*Other browser</label>
+  <input class="usa-input" id="browsers-other" name="browsers-other" type="text">
   <label class="usa-label" for="workflow">Briefly describe your testing workflow.</label>
   <textarea class="usa-textarea" id="workflow" name="workflow"></textarea>
   <fieldset class="usa-fieldset margin-top-3">

--- a/e2e/pages/signUp.js
+++ b/e2e/pages/signUp.js
@@ -11,7 +11,7 @@ const stringFields = [
   "state",
   "county",
   "facility-phone-number",
-  "other-facility",
+  "facility-type-other",
   "organization-name",
   "facility-name",
   "clia-number",

--- a/e2e/pages/signUp.js
+++ b/e2e/pages/signUp.js
@@ -16,7 +16,7 @@ const stringFields = [
   "facility-name",
   "clia-number",
   "testing-device-other",
-  "other-browser",
+  "browsers-other",
   "workflow",
   "op-first-name",
   "op-last-name",

--- a/pages/forms/account-request-form.html
+++ b/pages/forms/account-request-form.html
@@ -143,7 +143,7 @@ class: page-form
       "zip",
       "county",
       "facility-phone-number",
-      "other-facility",
+      "facility-type-other",
       "organization-name",
       "facility-name",
       "clia-number",

--- a/pages/forms/account-request-form.html
+++ b/pages/forms/account-request-form.html
@@ -148,7 +148,7 @@ class: page-form
       "facility-name",
       "clia-number",
       "testing-device-other",
-      "other-browser",
+      "browsers-other",
       "workflow",
       "op-first-name",
       "op-last-name",


### PR DESCRIPTION
Fixes https://github.com/CDCgov/prime-simplereport/issues/1677

This changes to property name used for other browsers to match the backend.