### PR TITLE
Add conditional requirement for Ordering Provider

### DIFF
--- a/_includes/forms/ordering-provider.html
+++ b/_includes/forms/ordering-provider.html
@@ -5,7 +5,8 @@
     public health department, as needed. All states (except for North Dakota)
     require ordering provider information.
   </p>
-  <label class="usa-label" for="op-first-name">First name</label>
+  <!-- Note that these labels & required-ness are set in Javascript -->
+  <label class="usa-label" for="op-first-name"></label>
   <input
     class="usa-input"
     id="op-first-name"
@@ -13,7 +14,7 @@
     type="text"
     spellcheck="false"
   />
-  <label class="usa-label" for="op-last-name">Last name</label>
+  <label class="usa-label" for="op-last-name"></label>
   <input
     class="usa-input"
     id="op-last-name"
@@ -21,9 +22,9 @@
     type="text"
     spellcheck="false"
   />
-  <label class="usa-label" for="npi">National Provider Identifier (NPI)</label>
-  <input class="usa-input" id="npi" name="npi" type="text" />
-  <label class="usa-label" for="op-phone-number">Phone number</label>
+  <label class="usa-label" for="npi"></label>
+  <input class="usa-input" id="npi" name="npi" type="text"/>
+  <label class="usa-label" for="op-phone-number"></label>
   <input
     class="usa-input"
     id="op-phone-number"

--- a/e2e/pages/signUp.js
+++ b/e2e/pages/signUp.js
@@ -54,7 +54,7 @@ allFields.forEach((field) => {
 });
 formElements.submitButton = "#form-submit-button";
 
-function signUp() {
+function fillAllFields() {
   this.expect.section("@app").to.be.visible;
   this.expect.section("@form").to.be.visible;
   stringFields.forEach((element) => {
@@ -73,6 +73,26 @@ function signUp() {
   this.api.execute(
     "document.getElementById('test-submission').checked = true;"
   );
+}
+
+function signUp() {
+  fillAllFields.apply(this);
+  this.section.form.click("@submitButton");
+  this.expect
+    .section("@app")
+    .to.contain.text("You’re on your way to simpler reporting!");
+}
+
+function orderingProviderOptionalForNorthDakota() {
+  fillAllFields.apply(this);
+  this.section.form.expect.element('@state').to.be.present;
+  this.section.form.setValue("@state", "NY");
+  this.section.form.expect.element('@npi').to.be.present;
+  this.section.form.clearValue("@npi");
+  this.section.form.click("@submitButton");
+  this.expect.section('@form').to.be.visible;
+
+  this.section.form.setValue("@state", "ND");
   this.section.form.click("@submitButton");
   this.expect
     .section("@app")
@@ -86,6 +106,7 @@ module.exports = {
   commands: [
     {
       signUp,
+      orderingProviderOptionalForNorthDakota,
     },
   ],
   sections: {

--- a/e2e/pages/signUp.js
+++ b/e2e/pages/signUp.js
@@ -85,12 +85,12 @@ function signUp() {
 
 function orderingProviderOptionalForNorthDakota() {
   fillAllFields.apply(this);
-  this.section.form.expect.element('@state').to.be.present;
+  this.section.form.expect.element("@state").to.be.present;
   this.section.form.setValue("@state", "NY");
-  this.section.form.expect.element('@npi').to.be.present;
+  this.section.form.expect.element("@npi").to.be.present;
   this.section.form.clearValue("@npi");
   this.section.form.click("@submitButton");
-  this.expect.section('@form').to.be.visible;
+  this.expect.section("@form").to.be.visible;
 
   this.section.form.setValue("@state", "ND");
   this.section.form.click("@submitButton");

--- a/e2e/tests/signUp.js
+++ b/e2e/tests/signUp.js
@@ -6,4 +6,10 @@ module.exports = {
       .navigate()
       .signUp();
   },
+  "2. Ordering provider conditionally required": (browser) => {
+    browser.page
+      .signUp()
+      .navigate()
+      .orderingProviderOptionalForNorthDakota();
+  },
 };

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -40,7 +40,7 @@ module.exports = {
           acceptInsecureCerts: true,
           "moz:firefoxOptions": {
             args: [
-              "-headless",
+              //"-headless",
               // '-verbose'
             ],
           },

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -40,7 +40,7 @@ module.exports = {
           acceptInsecureCerts: true,
           "moz:firefoxOptions": {
             args: [
-              //"-headless",
+              "-headless",
               // '-verbose'
             ],
           },

--- a/pages/forms/account-request-form.html
+++ b/pages/forms/account-request-form.html
@@ -296,11 +296,42 @@ class: page-form
      });
 
     /**
+     * Make Ordering Provider's name, NPI & phone required - but only outside of ND
+     */
+    const facilityState = document.getElementsByName('state').item(0);
+    const requiredHtml = '{% include required.html %}';
+    const opRequiredFields = {
+      'op-first-name': 'First name',
+      'op-last-name': 'Last name',
+      'op-phone-number': 'Phone number',
+      'npi': 'National Provider Identifier (NPI)'
+    }
+    function setOrderingProviderIsRequired() {
+      Object.keys(opRequiredFields).forEach(field => {
+        console.info(`trying ${field}`);
+        const input = document.getElementsByName(field).item(0);
+        const label = document.querySelector(`label[for=${field}]`);
+        const stateVal = state.value.toLowerCase();
+        if(stateVal.includes('nd') || stateVal.includes('north dakota')) {
+          input.required = false;
+          label.innerHTML = opRequiredFields[field];
+        } else {
+          input.required = true;
+          label.innerHTML = opRequiredFields[field] + ' ' + requiredHtml;
+        }
+      });
+    }
+    state.onchange = setOrderingProviderIsRequired;
+    setOrderingProviderIsRequired(); // initialize! 
+
+    /**
      * Aggregate the form data; validate the form; submit
      */
     button.onclick = async () => {
       submitted = true;
       const data = aggregateFormData();
+      console.log(data);
+      console.log(state.value);
 
       const formValid = form.reportValidity();
       const groupsValid = groupsAreValid(data);

--- a/pages/forms/account-request-form.html
+++ b/pages/forms/account-request-form.html
@@ -308,7 +308,6 @@ class: page-form
     }
     function setOrderingProviderIsRequired() {
       Object.keys(opRequiredFields).forEach(field => {
-        console.info(`trying ${field}`);
         const input = document.getElementsByName(field).item(0);
         const label = document.querySelector(`label[for=${field}]`);
         const stateVal = state.value.toLowerCase();
@@ -330,8 +329,6 @@ class: page-form
     button.onclick = async () => {
       submitted = true;
       const data = aggregateFormData();
-      console.log(data);
-      console.log(state.value);
 
       const formValid = form.reportValidity();
       const groupsValid = groupsAreValid(data);

--- a/pages/forms/account-request-form.html
+++ b/pages/forms/account-request-form.html
@@ -307,10 +307,10 @@ class: page-form
       'npi': 'National Provider Identifier (NPI)'
     }
     function setOrderingProviderIsRequired() {
+      const stateVal = state.value.toLowerCase();
       Object.keys(opRequiredFields).forEach(field => {
         const input = document.getElementsByName(field).item(0);
         const label = document.querySelector(`label[for=${field}]`);
-        const stateVal = state.value.toLowerCase();
         if(stateVal.includes('nd') || stateVal.includes('north dakota')) {
           input.required = false;
           label.innerHTML = opRequiredFields[field];

--- a/pages/forms/account-request-form.html
+++ b/pages/forms/account-request-form.html
@@ -296,7 +296,7 @@ class: page-form
      });
 
     /**
-     * Make Ordering Provider's name, NPI & phone required - but only outside of ND
+     * Make Ordering Provider's name, NPI & phone required - but not in ND
      */
     const facilityState = document.getElementsByName('state').item(0);
     const requiredHtml = '{% include required.html %}';


### PR DESCRIPTION
- Resolves https://github.com/CDCgov/prime-simplereport/issues/1646

This adds front end validation for the signup form to require the ordering provider's name, NPI, and telephone – except in North Dakota, where this information is not required by the state.

This is already enforced by the API, but it throws a 400 and those are not gracefully handled by the static site at this time

_Also, for the record: I'm sorry that this code exists_