### PR TITLE
changing reference from training to demo site

### DIFF
--- a/_pages/getting-started/organizations-and-testing-facilities/get-training.md
+++ b/_pages/getting-started/organizations-and-testing-facilities/get-training.md
@@ -11,8 +11,8 @@ return_top: 'true'
 Check out  our resources to get familiar with SimpleReport’s testing, reporting, and workflow features. 
 
 - Check out our [video introduction and onboarding guide](https://youtu.be/3YsfDprX2aw).
-- Practice using SimpleReport and take a look around on our [training site](https://training.simplereport.gov/app).
-- Have a look at our [resources page](https://simplereport.gov/resources).
+- Practice using SimpleReport and take a look around on our [demo site](https://training.simplereport.gov/app).
+- Have a look at our [resources pages](https://simplereport.gov/resources).
 - Review our [K-12 schools guide](https://simplereport.gov/assets/resources/k12-guide.pdf).
 
 Still have a question? Visit our [support page](https://simplereport.gov/support/).


### PR DESCRIPTION
To keep consistent with what we call it on the home page