### PR TITLE
Add a maintenance banner

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -48,3 +48,21 @@
     }
   }
 </script>
+
+<!-- Script for getting current maintenance mode status -->
+<script type="text/javascript">
+  (async function getMaintenanceMode() {
+    const maintenance = await fetch("/maintenance.json");
+    try {
+      const maintenanceJSON = await maintenance.json();
+      if (maintenanceJSON.active) {
+        const banner = document.getElementById("maintenance-banner");
+        const message = banner.querySelector('.usa-alert__text span');
+        message.textContent = maintenanceJSON.message;
+        banner.classList.remove("display-none");
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  })();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,16 @@ main: foo, bar, qaz
     {% endif %}
   </head>
   <body class="site-body {{ layout.class }} {{ page.class }} {% if site.site_width %}site-{{ site.site_width }}{% endif %}">
+    <section id="maintenance-banner" class="usa-site-alert usa-site-alert--emergency usa-site-alert--no-heading display-none" aria-label="Maintenance alert">
+      <div class="usa-alert">
+        <div class="usa-alert__body">
+          <p class="usa-alert__text">
+            <strong>SimpleReport is currently experiencing an outage.</strong>
+            <span>We're working on getting this fixed as soon as possible.</span>
+          </p>
+        </div>
+      </div>
+    </section>
 
     {% include skipnav.html %}
     {% if page.path != "pages/home.md" %}

--- a/maintenance.json
+++ b/maintenance.json
@@ -1,0 +1,4 @@
+{
+    "active": false,
+    "message": "We're working on getting this fixed as soon as possible."
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "postcss-csso": "^5.0.0",
     "postcss-uncss": "^0.17.0",
     "prettier": "2.0.5",
-    "sass": "^1.32.8",
+    "sass": "1.39.2",
     "uncss": "^0.17.3",
     "uswds": "^2.11.1",
     "uswds-gulp": "github:uswds/uswds-gulp",


### PR DESCRIPTION
Resolves https://github.com/CDCgov/prime-simplereport/issues/2315
Depends on https://github.com/CDCgov/prime-simplereport/pull/2545

Adds a maintenance banner to the top of the default layout and a script which fetches `/maintenance.json` and displays the included message if there is an active outage