### PR TITLE
Add activation email to static site assets

### DIFF
--- a/assets/user_emails/oktaActivation.html
+++ b/assets/user_emails/oktaActivation.html
@@ -1,0 +1,91 @@
+<!--EMAIL TEMPLATE FOR OKTA-->
+<!--LAST UPDATED VZ 8/19/21-->
+<body><!--REMOVE FOR OKTA-->
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
+        <meta name="viewport" content="width=device-width" />
+    </head>
+<!--BEGIN OKTA-->
+<style type="text/css">
+    a {color: #005ea2}
+</style>
+<div style="background-color:#f0f0f0;margin:0;padding:12px 0"> 
+  <table style="font-family:Public Sans Web, -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;font-size:14px;color:#1B1B1B;width:98%;max-width:600px;float:none;margin:0 auto" border="0" cellpadding="0" cellspacing="0" valign="top" align="left">
+    <tbody>
+      <tr bgcolor="#ffffff" align="middle">
+        <td style="padding-top:16px;padding-bottom:0px"><img src="https://simplereport.gov/assets/img/simplereport-logo-color-m-whitebg.png" height="57" /></td>
+      </tr>
+      <tr bgcolor="#ffffff">
+        <td> 
+          <table bgcolor="#ffffff" style="width:100%;line-height:20px;padding:32px;font-size:14px" cellpadding="0">
+            <tbody>
+              <tr>
+                <td style="vertical-align:bottom">Hi ${f:escapeHtml(user.firstName)},</td>
+              </tr>
+              <tr>
+                <td style="padding-top:24px">You’re all set! Simply activate your SimpleReport account and log in to get started with our free COVID-19 testing and reporting tool.</td>
+              </tr>
+              <tr>
+                <td style="padding-top:24px;padding-bottom:24px">
+                    <b>Username:</b> ${user.login}<br />
+                    <b>Log in page:</b> <a href="https://simplereport.gov" style="color:#005ea2">simplereport.gov</a>
+                </td>
+            </tr>
+            <tr>
+                <td align="center"> 
+                <table border="0" cellpadding="0" cellspacing="0" valign="top">
+                <tbody>
+                    <tr>
+                        <td align="center" style="padding:12px 16px;border-radius:3px;background-color: #005ea2;">
+                            <a id="unlock-account-link" href="${unlockAccountLink}" style="text-decoration:none">
+                                <span style="padding:12px 16px;text-align:center;cursor:pointer;color:#ffffff;font-size: 16px; font-weight: bold">Activate your account</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr>
+                    <td align="center" style="font-size:11px;color:#555555">This link expires in ${f:formatTimeDiffDateNowInUserLocale(unlockAccountTokenExpirationDate)}.</td>
+                    </tr>
+                </tbody>
+                </table> 
+                </td>
+            </tr>
+            <tr>
+                <td style="padding-top:24px;font-size:16px;font-weight:700">SimpleReport training and resources</td>
+            </tr>
+            <tr>
+                <td style="padding-top:24px">Check out our resources to get familiar with SimpleReport’s testing, reporting, and workflow features.</td>
+            </tr>
+
+            <tr>
+                <td style="padding-top:8px">
+                    &bull;&nbsp;Check out our video <a href="https://youtu.be/3YsfDprX2aw" style="color:#005ea2">introduction and onboarding guide</a>.<br />
+                    &bull;&nbsp;Practice using SimpleReport and take a look around on our <a href="https://training.simplereport.gov/" style="color:#005ea2">training site</a>.<br />
+                    &bull;&nbsp;Have a look at our <a href="https://simplereport.gov/resources" style="color:#005ea2">resources page</a>.
+                </td>
+            </tr>
+            <tr>
+                <td style="padding-top:24px">Still have questions? Visit our <a href="https://simplereport.gov/support/" style="color:#005ea2">Support page</a>.</td>
+            </tr>
+            <tr>
+                <td style="padding-top:24px">Thanks for choosing SimpleReport!</td>
+            </tr>
+            <tr>
+                <td style="padding-bottom:12px">&nbsp;</td>
+            </tr>
+            <tr>
+                <td style="padding-top:12px;border-top:1px solid #ccc;font-size:11px;"><a href="https://simplereport.gov/terms-of-service/" style="color:#005ea2">SimpleReport terms of service</a></td>
+            </tr>              
+            </tbody>
+          </table> 
+        </td>
+      </tr>
+      <tr>
+        <td style="font-size:12px;padding:16px 0 30px;color:#999">This is an automatically generated message from <a href="https://simplereport.gov" style="color:#616161">SimpleReport</a>.</td>
+      </tr>
+    </tbody>
+  </table> 
+</div>
+
+<!--END OKTA-->
+</body><!--REMOVE FOR OKTA-->


### PR DESCRIPTION
As we're updating the Okta custom emails, it would be nice to have a more reliable place to store them than in Okta itself. Added a folder to keep user-facing email templates and put @vz3's updated activation email there. 