### PR TITLE
Exclude all of /assets from sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,9 +17,8 @@ plugins:
   - jekyll-redirect-from
 
 defaults:
-  -
-    scope:
-      path: "assets/**/*.pdf"
+  - scope:
+      path: "assets/**"
     values:
       sitemap: false
 


### PR DESCRIPTION
## Related Issue or Background Info

Our email templates are turning up as search results.
https://usds.slack.com/archives/C01T5NC1WMN/p1633010047063700

## Changes Proposed

- Exclude all of `/assets` from our sitemap.  This should keep it from getting indexed by search.gov and showing up in the search results in the results on https://simplereport.gov/support/

## Additional Information

This is a more broad exclusion, but right now the only files that didn't match the old glob were the email templates, so effectively this only adds those to the exclusion.  For the future, this will keep us from accidentally indexing anything new we throw into the assets directory.
