### PR TITLE
Add K12 guide and user guide PDFs to search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,14 @@ defaults:
       path: "assets/**"
     values:
       sitemap: false
+  - scope:
+      path: "assets/resources/k12-guide.pdf"
+    values:
+      sitemap: true
+  - scope:
+      path: "assets/resources/SimpleReport-user-guide.pdf"
+    values:
+      sitemap: true
 
 exclude:
   - .jekyll-cache/


### PR DESCRIPTION
This adds `k12-guide.pdf` and `SimpleReport-user-guide.pdf` to the sitemap so that they will appear in search.