### PR TITLE
Point login button to React app instead of Okta

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ title: SimpleReport
 url: https://simplereport.gov
 dap_agency: HHS
 dap_subagency: CDC
+app_url: https://www.simplereport.gov/app
 okta_url: https://hhs-prime.okta.com/oauth2/default/v1/authorize?client_id=0oa5ahrdfSpxmNZO74h6&redirect_uri=https://www.simplereport.gov/app&response_type=token+id_token&scope=openid%20simple_report%20simple_report_prod&nonce=thisisnotsafe&state=thisisbogus
 permalink: pretty
 search_site_handle: simplereport

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -35,12 +35,10 @@ primary:
   href: "#"
   class: usa-button text-white padding-x-205 padding-y-105 font-ui-2xs margin-right-0
   onclick: "javascript:checkIe()"
-  external: true
 
 secondary:
   - text: Log in
-    href: {{ site.okta_url }}
-    external: true
+    href: {{ site.app_url }}
     class: usa-button usa-button--accent-cool text-no-underline text-ink wide-button
 
 getting-started:

--- a/_demo_config.yml
+++ b/_demo_config.yml
@@ -1,2 +1,3 @@
 url: https://demo.simplereport.gov
+app_url: https://demo.simplereport.gov/app
 okta_url: https://demo.simplereport.gov/app

--- a/_dev_config.yml
+++ b/_dev_config.yml
@@ -1,2 +1,3 @@
 url: https://dev.simplereport.gov
+app_url: https://dev.simplereport.gov/app
 okta_url: https://hhs-prime.oktapreview.com/oauth2/default/v1/authorize?client_id=0oa1khbp5n2wTfe281d7&redirect_uri=https://dev.simplereport.gov/app&response_type=token+id_token&scope=openid%20simple_report%20simple_report_dev&nonce=thisisnotsafe&state=thisisbogus

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -44,7 +44,7 @@
       if (window.navigator.userAgent.match(/MSIE|Trident/) !== null) {
       window.location.href = '{% link pages/unsupported-browser.html %}'
     } else {
-      window.location.href = decodeURI('{{ site.okta_url }}');
+      window.location.href = decodeURI('{{ site.app_url }}');
     }
   }
 </script>

--- a/_pentest_config.yml
+++ b/_pentest_config.yml
@@ -1,2 +1,3 @@
 url: https://pentest.simplereport.gov
+app_url: https://pentest.simplereport.gov/app
 okta_url: https://hhs-prime.oktapreview.com/oauth2/default/v1/authorize?client_id=0oa1hwvzb4X0sgGAt1d7&redirect_uri=https://pentest.simplereport.gov/app&response_type=token+id_token&scope=openid%20simple_report%20simple_report_pentest&nonce=thisisnotsafe&state=thisisbogus

--- a/_stg_config.yml
+++ b/_stg_config.yml
@@ -1,2 +1,3 @@
 url: https://stg.simplereport.gov
+app_url: https://stg.simplereport.gov/app
 okta_url: https://hhs-prime.okta.com/oauth2/default/v1/authorize?client_id=0oa62qncijWSeQMuc4h6&redirect_uri=https://stg.simplereport.gov/app&response_type=token+id_token&scope=openid%20simple_report%20simple_report_stg&nonce=thisisnotsafe&state=thisisbogus

--- a/_test_config.yml
+++ b/_test_config.yml
@@ -1,2 +1,3 @@
 url: https://test.simplereport.gov
+app_url: https://test.simplereport.gov/app
 okta_url: https://hhs-prime.oktapreview.com/oauth2/default/v1/authorize?client_id=0oa1khettjHnj3EPT1d7&redirect_uri=https://test.simplereport.gov/app&response_type=token+id_token&scope=openid%20simple_report%20simple_report_test&nonce=thisisnotsafe&state=thisisbogus

--- a/_training_config.yml
+++ b/_training_config.yml
@@ -1,2 +1,3 @@
 url: https://training.simplereport.gov
+app_url: https://training.simplereport.gov/app
 okta_url: https://training.simplereport.gov/app


### PR DESCRIPTION
Resolves https://github.com/CDCgov/prime-simplereport/issues/2811

Since the app now redirects to Okta if the user is not logged in, we can just point the login button at `/app`.