### PR TITLE
Change description tags to meta across the app

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -9,6 +9,11 @@
 <meta name="description" content="{{ description }}">
 {% endif %}
 
+{% assign pagemeta = page.meta %}
+{% if pagemeta %}
+<meta name="pagemeta" content="{{ pagemeta }}">
+{% endif %}
+
 {% include favicon.html %}
 <script src="{{ site.baseurl }}/assets/js/uswds-init.min.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />

--- a/_pages/getting-started/organizations-and-testing-facilities/activate-your-user-account.md
+++ b/_pages/getting-started/organizations-and-testing-facilities/activate-your-user-account.md
@@ -1,6 +1,6 @@
 ---
 title: Activate your organization or user account
-description: Activate your SimpleReport account and set up multi-factor authentication to begin COVID-19 testing and reporting.
+meta: Activate your SimpleReport account and set up multi-factor authentication to begin COVID-19 testing and reporting.
 layout: page
 class: page-docs page-docs-img-sm
 sidenav: resources

--- a/_pages/getting-started/organizations-and-testing-facilities/onboard-your-organization.md
+++ b/_pages/getting-started/organizations-and-testing-facilities/onboard-your-organization.md
@@ -1,6 +1,6 @@
 ---
 title: How to sign up for SimpleReport
-description: How to set up a SimpleReport account for your organization, workplace, or company.
+meta: How to set up a SimpleReport account for your organization, workplace, or company.
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/getting-started/public-health-departments/about-prime-reportstream.md
+++ b/_pages/getting-started/public-health-departments/about-prime-reportstream.md
@@ -1,6 +1,6 @@
 ---
 title: What is ReportStream?
-description: How public health departments use ReportStream to get data from SimpleReport
+meta: How public health departments use ReportStream to get data from SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/getting-started/public-health-departments/simplereport-data-catalog.md
+++ b/_pages/getting-started/public-health-departments/simplereport-data-catalog.md
@@ -1,6 +1,6 @@
 ---
 title: SimpleReport data catalog
-description: Types of data collected by SimpleReport and sent to public health departments
+meta: Types of data collected by SimpleReport and sent to public health departments
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/user-guide/index.md
+++ b/_pages/user-guide/index.md
@@ -1,6 +1,6 @@
 ---
 title: User guide
-description: A printable version of SimpleReport instructions found on our website
+meta: A printable version of SimpleReport instructions found on our website
 permalink: /user-guide/
 layout: page
 class: page-docs

--- a/_pages/using-simplereport/conduct-and-submit-tests/backdate-a-test.md
+++ b/_pages/using-simplereport/conduct-and-submit-tests/backdate-a-test.md
@@ -1,6 +1,6 @@
 ---
 title: Backdate a test
-description: How do you backdate COVID-19 test results in SimpleReport?
+meta: How do you backdate COVID-19 test results in SimpleReport?
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/conduct-and-submit-tests/index.md
+++ b/_pages/using-simplereport/conduct-and-submit-tests/index.md
@@ -1,6 +1,6 @@
 ---
 title: Conduct and submit tests
-description: How to conduct and submit COVID-19 tests in SimpleReport
+meta: How to conduct and submit COVID-19 tests in SimpleReport
 permalink: /using-simplereport/conduct-and-submit-tests/
 layout: page
 class: page-docs

--- a/_pages/using-simplereport/index.md
+++ b/_pages/using-simplereport/index.md
@@ -1,6 +1,6 @@
 ---
 title: Using SimpleReport
-description: Step-by-step instructions on how to use SimpleReport
+meta: Step-by-step instructions on how to use SimpleReport
 permalink: /using-simplereport/
 layout: page
 class: page-docs

--- a/_pages/using-simplereport/manage-facility-info/add-a-facility.md
+++ b/_pages/using-simplereport/manage-facility-info/add-a-facility.md
@@ -1,6 +1,6 @@
 ---
 title: Add a testing facility or location
-description: Add a testing facility or location to your SimpleReport organization account
+meta: Add a testing facility or location to your SimpleReport organization account
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-facility-info/find-supported-jurisdictions.md
+++ b/_pages/using-simplereport/manage-facility-info/find-supported-jurisdictions.md
@@ -1,6 +1,6 @@
 ---
 title: Where does SimpleReport work?
-description: Is SimpleReport in your state or territory?
+meta: Is SimpleReport in your state or territory?
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-facility-info/update-facility-settings.md
+++ b/_pages/using-simplereport/manage-facility-info/update-facility-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Update testing facility settings
-description: Update information about your testing site
+meta: Update information about your testing site
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-people-you-test/add-a-new-person.md
+++ b/_pages/using-simplereport/manage-people-you-test/add-a-new-person.md
@@ -1,6 +1,6 @@
 ---
 title: Add a new person
-description: How to test a new person in SimpleReport
+meta: How to test a new person in SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-people-you-test/archive-a-person.md
+++ b/_pages/using-simplereport/manage-people-you-test/archive-a-person.md
@@ -1,6 +1,6 @@
 ---
 title: Archive a person
-description: Removing someone you tested from SimpleReport
+meta: Removing someone you tested from SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-people-you-test/self-registration.md
+++ b/_pages/using-simplereport/manage-people-you-test/self-registration.md
@@ -1,6 +1,6 @@
 ---
 title: Self-registration
-description: How to set up patient self-registration for COVID-19 testing 
+meta: How to set up patient self-registration for COVID-19 testing 
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-people-you-test/update-someones-profile.md
+++ b/_pages/using-simplereport/manage-people-you-test/update-someones-profile.md
@@ -1,6 +1,6 @@
 ---
 title: Update someone’s profile
-description: How to make changes to a patient’s profile in SimpleReport
+meta: How to make changes to a patient’s profile in SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-results/correct-a-previous-test-result.md
+++ b/_pages/using-simplereport/manage-results/correct-a-previous-test-result.md
@@ -1,6 +1,6 @@
 ---
 title: Correct a previous test result
-description: How to make changes to COVID-19 test results in SimpleReport
+meta: How to make changes to COVID-19 test results in SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-results/print-someones-test-results.md
+++ b/_pages/using-simplereport/manage-results/print-someones-test-results.md
@@ -1,6 +1,6 @@
 ---
 title: Print someone’s test results
-description: How to print COVID-19 test results from SimpleReport
+meta: How to print COVID-19 test results from SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-results/review-results.md
+++ b/_pages/using-simplereport/manage-results/review-results.md
@@ -1,6 +1,6 @@
 ---
 title: Review results
-description: How to view patient’s COVID-19 test results in SimpleReport
+meta: How to view patient’s COVID-19 test results in SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-users/invite-new-users.md
+++ b/_pages/using-simplereport/manage-users/invite-new-users.md
@@ -1,6 +1,6 @@
 ---
 title: Add new users
-description: Create new SimpleReport accounts for staff and employees
+meta: Create new SimpleReport accounts for staff and employees
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-users/manage-user-permissions.md
+++ b/_pages/using-simplereport/manage-users/manage-user-permissions.md
@@ -1,6 +1,6 @@
 ---
 title: Manage user permissions
-description: Set staff and employee access in SimpleReport
+meta: Set staff and employee access in SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/manage-users/reactivate-users.md
+++ b/_pages/using-simplereport/manage-users/reactivate-users.md
@@ -1,6 +1,6 @@
 ---
 title: Reactivate users
-description: Reactivate testing facility staff accounts in SimpleReport
+meta: Reactivate testing facility staff accounts in SimpleReport
 layout: page
 class: page-docs
 sidenav: resources

--- a/_pages/using-simplereport/reset-your-simplereport-password.md
+++ b/_pages/using-simplereport/reset-your-simplereport-password.md
@@ -1,6 +1,6 @@
 ---
 title: Reset your SimpleReport password
-description: I forgot my SimpleReport password
+meta: I forgot my SimpleReport password
 layout: page
 class: page-docs page-docs-img-sm
 sidenav: resources

--- a/_pages/using-simplereport/select-your-testing-facility.md
+++ b/_pages/using-simplereport/select-your-testing-facility.md
@@ -1,6 +1,6 @@
 ---
 title: Select your testing facility
-description: How to find the location where you’re doing COVID-19 testing
+meta: How to find the location where you’re doing COVID-19 testing
 layout: page
 class: page-docs
 sidenav: resources

--- a/pages/about-us.md
+++ b/pages/about-us.md
@@ -1,6 +1,6 @@
 ---
 title: About us
-description: SimpleReport is a free COVID-19 testing and reporting app created by the CDC and the USDS
+meta: SimpleReport is a free COVID-19 testing and reporting app created by the CDC and the USDS
 permalink: /about-us/
 layout: post
 return_top: 'false'

--- a/pages/home.md
+++ b/pages/home.md
@@ -1,6 +1,6 @@
 ---
 title: Home
-description: SimpleReport is a COVID-19 testing and reporting tool that sends results to your public health department.
+meta: SimpleReport is a COVID-19 testing and reporting tool that sends results to your public health department.
 permalink: /
 layout: home
 class: page-home

--- a/pages/support.html
+++ b/pages/support.html
@@ -1,6 +1,6 @@
 ---
 permalink: /support/
-description: Get information and support to help you use SimpleReport for COVID-19 testing and reporting
+meta: Get information and support to help you use SimpleReport for COVID-19 testing and reporting
 layout: home
 return_top: 'false'
 ---


### PR DESCRIPTION
PR #252 added metadata to the static site, but did so using `description` tags which also provide a subheader for the page. These tags were only meant to be used as metadata, so I added a new rule that reads `page.meta` fields and creates a meta tag for it.