### PR TITLE
Fix breadcrumb miscapitilzation

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -17,10 +17,10 @@
         href="{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}"
       >
         {% assign crumb_array = crumb | remove:'.html' | split: "-" %} {%
-        capture titlecase %} {% for word in crumb_array %} {% if forloop.first%}
-        {{ word | capitalize }} {% elsif word == "simplereport" %} SimpleReport
-        {% else %} {{word}} {% endif %} {% endfor %}{% endcapture %} {{
-        titlecase }}
+        capture setence_case %} {% for word in crumb_array %} {% if
+        forloop.first%} {{ word | capitalize }} {% elsif word == "simplereport"
+        %} SimpleReport {% else %} {{word}} {% endif %} {% endfor %}{%
+        endcapture %} {{ setence_case }}
       </a>
     </li>
     {% endif %} {% endfor %}


### PR DESCRIPTION
Noticed that SimpleReport was miscapitalized in the breadcrumb component when implementing the New Features page. Adding in a change to fix that

Before:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/29645040/159077276-0bcd0026-9272-4d61-93f3-d468cc7d4bf3.png">


After:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/29645040/159077231-3cdeabe6-9a8d-4d5c-afdc-ec8c585435af.png">
