### PR TITLE
Add aria-label to gov-banner

### DIFF
--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -10,7 +10,7 @@
           <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
         </div>
         <button class="usa-accordion__button usa-banner__button"
-          aria-expanded="false" aria-controls="gov-banner">
+          aria-expanded="false" aria-controls="gov-banner" aria-label="Here's how you know this is an official website">
           <span class="usa-banner__button-text">Here’s how you know</span>
         </button>
       </div>


### PR DESCRIPTION
https://github.com/CDCgov/prime-simplereport/issues/4033

Just blatantly stealing the label that the VA site uses