### PR TITLE
Make "More" btn on support pg keyboard navigable

### DIFF
--- a/pages/support.html
+++ b/pages/support.html
@@ -36,17 +36,19 @@ return_top: 'false'
                         <h2 class="usa-card__heading">Account management</h2>
                     </header>
                     <div class="usa-card__body display-flex flex-column">
-                        <a href="/using-simplereport/reset-your-simplereport-password/">Reset your password</a>
-                        <a href="/getting-started/organizations-and-testing-facilities/activate-your-user-account/#multi-factor-authentication-options">Multi-factor authentication</a>
-                        <a href="/using-simplereport/manage-users/">Manage users</a>
-                        <a class="hidden-link display-none" href="/using-simplereport/manage-facility-info/">Manage facility info</a>
+                        <a class="usa-link" href="/using-simplereport/reset-your-simplereport-password/">Reset your password</a>
+                        <a class="usa-link" href="/getting-started/organizations-and-testing-facilities/activate-your-user-account/#multi-factor-authentication-options">Multi-factor authentication</a>
+                        <a class="usa-link" href="/using-simplereport/manage-users/">Manage users</a>
+                        <a class="usa-link hidden-link display-none" href="/using-simplereport/manage-facility-info/">Manage facility info</a>
                     </div>
                     <div class="divider"></div>
                     <div class="usa-card__footer grid-row">
-                        <span class="footer-text">More</span>
-                        <svg class="usa-icon margin-left-auto" aria-hidden="true" role="img">
-                            <use xlink:href="/assets/uswds/img/sprite.svg#add"></use>
-                        </svg>
+                        <button class="usa-button usa-button--unstyled grid-col-12 display-flex flex-align-center">
+                            <span class="footer-text">More</span>
+                            <svg class="usa-icon margin-left-auto" aria-hidden="true" role="img">
+                                <use xlink:href="/assets/uswds/img/sprite.svg#add"></use>
+                            </svg>
+                        </button>
                     </div>
                 </div>
             </li>
@@ -56,17 +58,19 @@ return_top: 'false'
                         <h2 class="usa-card__heading">Testing</h2>
                     </header>
                     <div class="usa-card__body display-flex flex-column">
-                        <a href="/using-simplereport/conduct-and-submit-tests/">Conduct and submit tests</a>
-                        <a href="/using-simplereport/manage-results/">Manage results</a>
-                        <a href="/using-simplereport/manage-people-you-test/">Manage people you test</a>
-                        <a class="hidden-link display-none" href="/using-simplereport/select-your-testing-facility/">Select your testing facility</a>
+                        <a class="usa-link" href="/using-simplereport/conduct-and-submit-tests/">Conduct and submit tests</a>
+                        <a class="usa-link" href="/using-simplereport/manage-results/">Manage results</a>
+                        <a class="usa-link" href="/using-simplereport/manage-people-you-test/">Manage people you test</a>
+                        <a class="usa-link hidden-link display-none" href="/using-simplereport/select-your-testing-facility/">Select your testing facility</a>
                     </div>
                     <div class="divider"></div>
                     <div class="usa-card__footer grid-row">
-                        <span class="footer-text">More</span>
-                        <svg class="usa-icon margin-left-auto" aria-hidden="true" role="img">
-                            <use xlink:href="/assets/uswds/img/sprite.svg#add"></use>
-                        </svg>
+                        <button class="usa-button usa-button--unstyled grid-col-12 display-flex flex-align-center">
+                            <span class="footer-text">More</span>
+                            <svg class="usa-icon margin-left-auto" aria-hidden="true" role="img">
+                                <use xlink:href="/assets/uswds/img/sprite.svg#add"></use>
+                            </svg>
+                        </button>
                     </div>
                 </div>
             </li>
@@ -76,18 +80,20 @@ return_top: 'false'
                         <h2 class="usa-card__heading">Getting started</h2>
                     </header>
                     <div class="usa-card__body tall display-flex flex-column">
-                        <a href="/sign-up">Sign up</a>
-                        <a href="/using-simplereport/manage-facility-info/add-a-facility/">Add a testing facility</a>
-                        <a href="/using-simplereport/manage-facility-info/find-supported-jurisdictions/">Where does SimpleReport work?</a>
-                        <a class="hidden-link display-none" href="/getting-started/organizations-and-testing-facilities/activate-your-user-account/">Activate your user account</a>
-                        <a class="hidden-link display-none" href="/getting-started/organizations-and-testing-facilities/log-in-to-simplereport/">Log in</a>
+                        <a class="usa-link" href="/sign-up">Sign up</a>
+                        <a class="usa-link" href="/using-simplereport/manage-facility-info/add-a-facility/">Add a testing facility</a>
+                        <a class="usa-link" href="/using-simplereport/manage-facility-info/find-supported-jurisdictions/">Where does SimpleReport work?</a>
+                        <a class="usa-link hidden-link display-none" href="/getting-started/organizations-and-testing-facilities/activate-your-user-account/">Activate your user account</a>
+                        <a class="usa-link hidden-link display-none" href="/getting-started/organizations-and-testing-facilities/log-in-to-simplereport/">Log in</a>
                     </div>
                     <div class="divider"></div>
                     <div class="usa-card__footer grid-row">
-                        <span class="footer-text">More</span>
-                        <svg class="usa-icon margin-left-auto" aria-hidden="true" role="img">
-                            <use xlink:href="/assets/uswds/img/sprite.svg#add"></use>
-                        </svg>
+                        <button class="usa-button usa-button--unstyled grid-col-12 display-flex flex-align-center">
+                            <span class="footer-text">More</span>
+                            <svg class="usa-icon margin-left-auto" aria-hidden="true" role="img">
+                                <use xlink:href="/assets/uswds/img/sprite.svg#add"></use>
+                            </svg>
+                        </button>
                     </div>
                 </div>
             </li>


### PR DESCRIPTION
Resolves https://github.com/CDCgov/prime-simplereport/issues/4040

**Changes**
- make the "More/Less" button an actual button that expands/hides the extra content on the "Support" page
- update the links on the "Support" page to use the `usa-link` class

**How to Test**
1. Go to `/support`
2. Ensure you are able to navigate to the "More"/"Less" buttons via the keyboard
3. Ensure the "More"/"Less" button expands/hides the extra links
4. See that the links on that page use the `usa-link` class

**Additional Info**
- Other links will need to be updated to use the `usa-link` class, to ensure the scope of this change is small I created a story about updating the links on the rest of the static site: https://github.com/CDCgov/prime-simplereport/issues/4122
