### PR TITLE
update the alt text for animations

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -85,7 +85,7 @@ return_top: 'false'
     <div class="grid-row margin-top-5">
       <div class="display-flex flex-justify-end flex-align-end tablet:display-none">
         <img class="brown-bubble" src="{{ '/assets/img/brown-bubble.svg' | relative_url }}" alt="brown bubble">
-        <img class="animation-1" src="{{ '/assets/img/animation1.gif' | relative_url }}" alt="animation 1">
+        <img class="animation-1" src="{{ '/assets/img/animation1.gif' | relative_url }}" alt="search by patient name">
       </div>
       <div class="grid-row tablet:grid-gap-6 display-flex">
         <div class="tablet:grid-col-6 flex-align-self-center">
@@ -99,7 +99,7 @@ return_top: 'false'
         <div class="display-none tablet:display-block grid-col-6">
           <div class="display-flex flex-justify-end flex-align-end">
             <img class="brown-bubble" src="{{ '/assets/img/brown-bubble.svg' | relative_url }}" alt="brown bubble">
-            <img class="animation-1" src="{{ '/assets/img/animation1.gif' | relative_url }}" alt="animation 1">
+            <img class="animation-1" src="{{ '/assets/img/animation1.gif' | relative_url }}" alt="search by patient name">
           </div>
         </div>
       </div>
@@ -107,7 +107,7 @@ return_top: 'false'
         <div class="tablet:grid-col-6">
           <div class="display-flex">
           <img class="blue-bubble flex-align-self-start" src="{{ '/assets/img/blue-bubble.svg' | relative_url }}" alt="blue bubble">
-          <img class="animation-2" src="{{ '/assets/img/animation2.gif' | relative_url }}" alt="animation 2">
+          <img class="animation-2" src="{{ '/assets/img/animation2.gif' | relative_url }}" alt="submit test result">
           </div>
         </div>
         <div class="tablet:grid-col-6">


### PR DESCRIPTION
Resolves [#4031](https://github.com/cdcgov/prime-simplereport/issues/4031)

**Changes**
- Update the alt text of the images on the home page
  - Alt text is now "search by patient name"
  ![image](https://dev.simplereport.gov/assets/img/animation1.gif)


  - Alt text is now "submit test result"
  ![image](https://dev.simplereport.gov/assets/img/animation2.gif)

**How to Test**
1. View the alt text for the images on the  on the main page.
![image](https://user-images.githubusercontent.com/10108172/183500086-0898621a-448f-4541-9e27-ebb0c2cb7ff1.png)

**Additional Info**
