### PR TITLE
Update alt txt for img on invite new users page

### DIFF
--- a/_pages/using-simplereport/manage-users/invite-new-users.md
+++ b/_pages/using-simplereport/manage-users/invite-new-users.md
@@ -13,7 +13,7 @@ Admins can give staff and employees SimpleReport access by adding them directly 
 To add a new user:
 
 1. Click the gear icon at the top right corner of the page.
-   ![The "Manage Users" tab selected in SimpleReport]({% link assets/img/resources/invite-new-users/step-1.png %})
+   ![Settings tab selected in SimpleReport]({% link assets/img/resources/invite-new-users/step-1.png %})
 2. Beneath the SimpleReport logo at the top of the page, find the “Manage Organization”, “Manage Facilities”, and “Manage Users” tabs. Click **Manage Users**.
    ![The “Manage Users” tab selected in SimpleReport]({% link assets/img/resources/invite-new-users/step-2.png %})
 3. Under “Users”, click **+ New user** in the top right corner.


### PR DESCRIPTION
Resolves: https://app.zenhub.com/workspaces/simplereport-accessibility-61153c23e7546f0010407728/issues/cdcgov/prime-simplereport/4108

**Proposed Changes**
- update alt text of first image on `/using-simplereport/manage-users/invite-new-users/` so it accurately describes the image


**How to Test**
Go to `/using-simplereport/manage-users/invite-new-users/` and see that the first image's alt text is changed to "Settings tab selected in SimpleReport"

**Screenshot**
<img width="1290" alt="Screen Shot 2022-08-11 at 10 44 07 AM" src="https://user-images.githubusercontent.com/20211771/184177140-c5f9b0a2-0dca-4a81-8bdb-7facce5bb238.png">

