### PR TITLE
remove extra script tag declaration

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -42,5 +42,3 @@ main:
     {% endif %}
   </div>
 </div>
-
-{% include scripts.html %}


### PR DESCRIPTION
fixes [4096](https://github.com/CDCgov/prime-simplereport/issues/3947). 

The issue was that the USWDS script was getting loaded in two page templates and the Javascript was freaking out. Removed the secondary `scripts.html` invocation and things are working as expected again.

Deployed the [static site in dev](https://dev.simplereport.gov/getting-started/public-health-departments/simplereport-data-catalog/) and the accordions are working now.