### PR TITLE
Trap focus when touchpoints modal is open

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -68,4 +68,5 @@ _src %}
 
 {% if site.touchpoints %}
 <script async src="/assets/js/touchpoints.js"> </script>
+<script async src="/assets/js/sr-touchpoints.js"></script>
 {% endif %}

--- a/assets/js/sr-touchpoints.js
+++ b/assets/js/sr-touchpoints.js
@@ -1,0 +1,73 @@
+// custom touchpoints modifications for improved accessibility
+'use strict';
+
+function initCustomTouchpointsJS() {
+  const TOUCHPOINTS_MODAL_CLASS = ".fba-modal";
+  const TOUCHPOINTS_BUTTON_ID = "#fba-button";
+  // NOTE: Will need to update this if there are multiple "Other" options + "Other" text inputs; currently this supports only one
+  const TOUCHPOINTS_OTHER_INPUT_ID = "#answer_01_other";
+  const TOUCHPOINTS_OTHER_RADIO_ID = "#answer_01_3";
+  const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+  // modified from https://uxdesign.cc/how-to-trap-focus-inside-modal-to-make-it-ada-compliant-6a50f9a70700
+  // traps keyboard focus when tabbing through touchpoints modal
+  function attachTabEventListener(modal) {
+    // get first element to be focused inside modal
+    const firstFocusableElement = modal.querySelectorAll(focusableElements)[0];
+    const focusableContent = modal.querySelectorAll(focusableElements);
+    // get last element to be focused inside modal
+    const lastFocusableElement = focusableContent[focusableContent.length - 1];
+
+    document.addEventListener("keydown", function (e) {
+      let isTabPressed = e.key === "Tab" || e.keyCode === 9;
+
+      if (!isTabPressed) {
+        return;
+      }
+
+      // if shift key pressed for shift + tab combination
+      if (e.shiftKey) {
+        if (document.activeElement === firstFocusableElement) {
+          lastFocusableElement.focus();
+          e.preventDefault();
+        }
+        // if tab key is pressed
+      } else {
+        if (document.activeElement === lastFocusableElement) {
+          // if focus reached last focusable element then focus first focusable element after pressing tab
+          firstFocusableElement.focus();
+          e.preventDefault();
+        }
+      }
+    });
+  }
+
+  // disable "Other" text input if "Other" radio btn isn't selected otherwise on tab through it will force selection of "Other" radio btn
+  function toggleInputDisabledAttr(textId) {
+    let otherRadioElem = document.querySelector(TOUCHPOINTS_OTHER_RADIO_ID);
+    let isOtherChecked = otherRadioElem.checked;
+    document.querySelector(textId).disabled = !isOtherChecked;
+  }
+
+  function attachRadioChangeEventListener() {
+    document.addEventListener("change", function () {
+      toggleInputDisabledAttr(TOUCHPOINTS_OTHER_INPUT_ID);
+    });
+  }
+
+  function attachModalToggleListener() {
+    const touchpointsModalButton = document.querySelector(TOUCHPOINTS_BUTTON_ID);
+    touchpointsModalButton.addEventListener("click", function (e) {
+      const modal = document.querySelector(TOUCHPOINTS_MODAL_CLASS);
+      if (modal !== null && window.getComputedStyle(modal).display === "block") {
+        attachTabEventListener(modal);
+        toggleInputDisabledAttr(TOUCHPOINTS_OTHER_INPUT_ID);
+        attachRadioChangeEventListener();
+      }
+    });
+  }
+
+  attachModalToggleListener();
+}
+
+initCustomTouchpointsJS();

--- a/assets/js/touchpoints.js
+++ b/assets/js/touchpoints.js
@@ -1,5 +1,6 @@
 /**
  * Script taken from our touchpoints configuration here: https://touchpoints.app.cloud.gov/touchpoints/2a6e9509.js
+ * NOTE: When updating script ensure sr-touchpoints.js works as intended
  */
 
 // Form components are namespaced under 'fba' = 'Feedback Analytics'


### PR DESCRIPTION
## Related Issue
Resolves https://github.com/CDCgov/prime-simplereport/issues/4030

## Changes
- ensures that keyboard focus is trapped when the touchpoints modal is open
- ensures the "Other" text input is disabled if the user has not selected the "Other" radio button option

## How to Test
- Open the touchpoints modal on any page
- Tab and shift + tab through the form, the keyboard focus should never leave the touchpoints modal
- When tabbing through the form, you should only tab to the "Other" text input if you selected the "Other" radio option
- Try switching back and forth from the "Other" radio option and the non-"Other" radio options to ensure the text input behaves as intended

## Demo

https://user-images.githubusercontent.com/20211771/186011632-c408c8d4-a6ee-47a4-a0d9-43c40c4aaee7.mov

## Additional Info
I noticed this behavior in the SimpleReport app as well and created a new issue: https://github.com/CDCgov/prime-simplereport/issues/4195