### PR TITLE
update content on homepage to be span

### DIFF
--- a/_includes/components/hero.html
+++ b/_includes/components/hero.html
@@ -17,9 +17,9 @@
         <h1 class="margin-top-3 mobile-lg:margin-top-1">
           <img src="{{ '/assets/img/SimpleReportLogo.svg' | relative_url }}" alt="SimpleReport logo">
         </h1>
-        <h2>
-        {{ hero.content }}
-        </h2>
+        <span>
+          {{ hero.content }}
+        </span>
 
         {% if hero.button %}
         <a class="usa-button usa-button--accent-cool tablet:margin-left-8 margin-top-2"

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -230,7 +230,8 @@ Typography
   padding: 0;
 
   h1,
-  h2 {
+  h2,
+  span {
     font-style: normal;
     font-weight: 500;
     font-size: 32px;
@@ -256,10 +257,15 @@ Typography
     margin-top: 0;
   }
 
-  h2 {
+  h2,
+  span {
     @include at-media("tablet") {
       margin-left: 2em;
     }
+  }
+
+  span{
+    display: block;
   }
 }
 


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- [#4036](https://github.com/CDCgov/prime-simplereport/issues/4036)

## Changes Proposed

- Change`<h2>` to `<span>` as this content is NOT a header. 
- Give span the same styling as h2 for the specific `usa-hero__callout` block.


## Additional Information

## Testing

- Compare local home page vs [dev.simplereport.gov](dev.simplereport.gov)

## Screenshots / Demos

SPAN:
![image](https://user-images.githubusercontent.com/10108172/186015967-0e40d733-bb86-40c5-8cc2-b23d35ee0d6b.png)
H2: 
![image](https://user-images.githubusercontent.com/10108172/186016361-a3489c7e-c9f8-4218-b4e1-514acb18dc44.png)
----
SPAN:
![image](https://user-images.githubusercontent.com/10108172/186016014-70231816-0d56-4091-9ada-1874a0e1d0f1.png)
H2:
![image](https://user-images.githubusercontent.com/10108172/186016485-1ed0ad2b-5515-437e-93f9-8c9ec4a1f1cc.png)
----
SPAN:
![image](https://user-images.githubusercontent.com/10108172/186016058-63bce84a-1dcf-4adf-a95d-cc2af5a54661.png)
H2:
![image](https://user-images.githubusercontent.com/10108172/186016419-e29f0310-5048-45d7-8beb-dfea37458adc.png)

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README