### PR TITLE
update the alt text to 'SimpleReport logo'

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -22,7 +22,7 @@ type: basic
 # If the logo is external add external: true
 logo:
   src: /assets/img/simple-report-logo-color.svg
-  alt: SimpleReport
+  alt: SimpleReport logo
 
 # this is a key into _data/navigation.yml
 primary:


### PR DESCRIPTION
# FRONTEND PULL REQUEST

## Related Issue
- [#4037](https://github.com/CDCgov/prime-simplereport/issues/4037)

## Changes Proposed

- Update alt text from "SimpleReport" to "SimpleReport logo" to be more descriptive.

## Additional Information

## Testing

- View heading on /getting-started pages

## Screenshots / Demos

![image](https://user-images.githubusercontent.com/10108172/186147102-08263310-7acc-4fce-995a-5d0a74f09b71.png)

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team
- [ ] Any changes to support infrastructure have been demo'd to support team

### Security
- [ ] Changes with security implications have been approved by a security engineer (changes to  authentication, encryption, handling of PII, etc.)
- [ ] Any dependencies introduced have been vetted and discussed

### Documentation
- [ ] Any changes to the startup configuration have been documented in the README