### PR TITLE
Prevent auto deploys to dev envs and pentest on merges to main

### DIFF
--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -2,9 +2,6 @@ name: Deploy Dev
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build-deploy:

--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -2,9 +2,6 @@ name: Deploy Dev2
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build-deploy:

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -2,9 +2,6 @@ name: Deploy Dev3
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build-deploy:

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -2,9 +2,6 @@ name: Deploy Dev4
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build-deploy:

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -2,9 +2,6 @@ name: Deploy to pentest
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build-deploy:


### PR DESCRIPTION
## Related Issue or Background Info

This PR makes the deploy triggers for the static site similar to the SimpleReport app. All the dev environments and pentest will only deploy when someone triggers the deploy action. This will now prevent auto deploys when there is a merge to `main`.

## Changes Proposed
See above

## Additional Information
<!--- decisions that were made, discussion of tradeoffs / future work, complaints about how bad the code is, etc -->
N/A 

## Screenshots / Demos

## Checklist for Author and Reviewer


### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify
