### PR TITLE
add redirect

### DIFF
--- a/_pages/resources/index.md
+++ b/_pages/resources/index.md
@@ -1,13 +1,13 @@
 ---
 title: Resources
 description:
-permalink: /resources/
+permalink: /resources/getting-started/
 layout: page
 class: page-docs
 sidenav: resources
 home_link: true
-return_top: 'true'
-redirect_to: /using-simplereport/
+return_top: "true"
+redirect_to: /getting-started/
 ---
 
 Welcome to SimpleReport. We’ve put together a number of articles to help you get started and use SimpleReport, from activating your account to running tests and troubleshooting common issues.


### PR DESCRIPTION
## Related Issue or Background Info
- fixes [4123](https://github.com/CDCgov/prime-simplereport/issues/4123) by adding a redirect to the old `resources/getting-started` page

Visiting the old url should result in a redirect to the new page. Redirect is live in dev for testing: https://dev.simplereport.gov/resources/getting-started/ 
