### PR TITLE
remove mid wave alt text

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -185,7 +185,7 @@ return_top: 'false'
 </section>
 
 <section>
-  <img class="mid-wave-top" src="{{ '/assets/img/mid-wave-top.svg' | relative_url }}" alt="mid wave top">
+  <img class="mid-wave-top" src="{{ '/assets/img/mid-wave-top.svg' | relative_url }}" alt="">
   <div class="bg-accent-cool-lighter padding-y-2 tablet:padding-y-0">
     <div class="grid-container">
       <div class="usa-prose">
@@ -200,7 +200,7 @@ return_top: 'false'
       </div>
     </div>
   </div>
-  <img class="mid-wave-bottom" src="{{ '/assets/img/mid-wave-bottom.svg' | relative_url }}" alt="mid wave bottom">
+  <img class="mid-wave-bottom" src="{{ '/assets/img/mid-wave-bottom.svg' | relative_url }}" alt="">
 </section>
 
 <section class="usa-section padding-top-0">

--- a/pages/home.md
+++ b/pages/home.md
@@ -161,14 +161,14 @@ return_top: 'false'
 </section>
 
 <section>
-  <img class="mid-wave-top" src="{{ '/assets/img/mid-wave-top.svg' | relative_url }}" alt="mid wave top">
+  <img class="mid-wave-top" src="{{ '/assets/img/mid-wave-top.svg' | relative_url }}" alt="">
   <div class="bg-accent-cool-lighter padding-y-2 tablet:padding-y-0">
     <div class="grid-container usa-prose">
       <p class="usa-intro">Check out the SimpleReport demo to try out features using sample data. See how SimpleReport could work for you.</p>
       <a class="usa-button text-no-underline text-white" href="https://training.simplereport.gov/app">Go to the demo</a>
     </div>
   </div>
-  <img class="mid-wave-bottom" src="{{ '/assets/img/mid-wave-bottom.svg' | relative_url }}" alt="mid wave bottom">
+  <img class="mid-wave-bottom" src="{{ '/assets/img/mid-wave-bottom.svg' | relative_url }}" alt="">
 </section>
 
 <section class="margin-y-4 tablet:margin-top-0 tablet:margin-bottom-4">


### PR DESCRIPTION
## Related Issue or Background Info
<!--- link to issue, or a few sentences describing why this PR exists -->

[- Decorative images should not have alt text](https://www.w3.org/WAI/tutorials/images/decorative/)
## Changes Proposed

- remove alt text from mid wave from image