### PR TITLE
remove offending h1 tag in template

### DIFF
--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -21,7 +21,6 @@
               class="usa-logo-img width-15 desktop:width-card-lg"
               src="{% if header.logo.external %}{{ header.logo.src }}{% else %}{{ header.logo.src | relative_url }}{% endif %}"
               alt="{{ header.logo.alt }}">
-            <h1 class='usa-sr-only'>{{header.logo.alt}}</h1>
           {% else %}
           <em class="usa-logo__text">
             {{ header.title | default: site.title }}


### PR DESCRIPTION
## Related Issue or Background Info
- Fixes [4447](https://app.zenhub.com/workspaces/simplereport-accessibility-61153c23e7546f0010407728/issues/cdcgov/prime-simplereport/4447)

## Changes Proposed
- Remove offending line in the site template


## Screenshots / Demos


<img width="1382" alt="Screen Shot 2022-10-18 at 1 39 12 PM" src="https://user-images.githubusercontent.com/29645040/196516294-268fb908-3e2f-4140-83fd-750d41cc1ea8.png">
<img width="1374" alt="Screen Shot 2022-10-18 at 1 35 14 PM" src="https://user-images.githubusercontent.com/29645040/196516123-78db0572-fdef-44f8-8a0e-5646edb22cd1.png">
