### PR TITLE
Add password reset link

### DIFF
--- a/_pages/using-simplereport/manage-users/reactivate-users.md
+++ b/_pages/using-simplereport/manage-users/reactivate-users.md
@@ -8,7 +8,7 @@ home_link: true
 return_top: "true"
 ---
 
-SimpleReport deactivates users after 60 days without logging in. Organization admins can reactivate users in SimpleReport.
+SimpleReport deactivates users after 60 days without logging in. Organization admins can reactivate users in SimpleReport. (If you’re looking for help with your password, learn how to [reset it on your own](https://www.simplereport.gov/using-simplereport/reset-your-simplereport-password).)
 
 To reactivate a user:
 


### PR DESCRIPTION
Adding link to "Reset your password" page, per conversation with Support team

## Additional Information
In discussion with Support around friction with account reactivation and password resets, they recommended we add password reset page link to the top of "Reactivate user" page.