### PR TITLE
Update homepage messaging

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -192,7 +192,7 @@ return_top: 'false'
         <h2 class="font-heading-3 text-primary-darker">
           Ready to simplify your COVID-19 reporting?
         </h2>
-        <p class="usa-intro">If you’re in a location where SimpleReport is already set up, you can sign up now. If you’re not, join the waitlist and we’ll let you know when SimpleReport comes to your area.</p>
+        <p class="usa-intro">If report to a location where SimpleReport is already set up, you can sign up now. If not, join the waitlist and we’ll let you know when SimpleReport is available to you.</p>
       </div>
       <div class="margin-top-2">
         <a class="usa-button text-no-underline font-body-sm" href="/app/sign-up">Sign up</a>

--- a/pages/home.md
+++ b/pages/home.md
@@ -15,7 +15,7 @@ return_top: 'false'
           <img src="{{ '/assets/img/SimpleReportLogo.svg' | relative_url }}" alt="SimpleReport">
         </h1>
         <span>
-          A better way to report COVID-19 rapid tests
+          A better way to report COVID-19 tests
         </span>
         <a class="usa-button usa-button--accent-cool tablet:margin-left-8 margin-top-2"
           href="/app/sign-up">
@@ -35,7 +35,7 @@ return_top: 'false'
           alt="simplereport displayed on a tablet">
       </div>
       <div class="tablet:grid-col usa-hero-subsection usa-prose flex-align-self-center">
-        <p>SimpleReport is a fast, free, and easy way for COVID-19 testing facilities to report results to public health departments.</p>
+        <p>SimpleReport is a fast, free, and easy way for your organization to report results to public health departments.</p>
         <ul class="margin-left-1">
           <li>
             Easy to set up and use
@@ -44,7 +44,7 @@ return_top: 'false'
             100% free
           </li>
           <li>
-            Works with any rapid point-of-care test
+            Works with any diagnostic test
           </li>
           <li>
             Maintains HIPAA standards
@@ -82,7 +82,7 @@ return_top: 'false'
             No more repeat data entry
           </h3>
           <p class="usa-intro line-height-sans-4 margin-bottom-0">
-            Skip re-entering the same data every time you report. Just pull up a name, enter the test result, and submit. It’s that easy.
+            Skip re-entering the same data every time you report. Just pull up a name and click a few buttons, or upload a spreadsheet. It’s that easy.
           </p>
         </div>
         <div class="display-none tablet:display-block grid-col-6">

--- a/pages/home.md
+++ b/pages/home.md
@@ -192,7 +192,7 @@ return_top: 'false'
         <h2 class="font-heading-3 text-primary-darker">
           Ready to simplify your COVID-19 reporting?
         </h2>
-        <p class="usa-intro">If report to a location where SimpleReport is already set up, you can sign up now. If not, join the waitlist and we’ll let you know when SimpleReport is available to you.</p>
+        <p class="usa-intro">If you report to a location where SimpleReport is already set up, you can sign up now. If not, join the waitlist and we’ll let you know when SimpleReport is available to you.</p>
       </div>
       <div class="margin-top-2">
         <a class="usa-button text-no-underline font-body-sm" href="/app/sign-up">Sign up</a>


### PR DESCRIPTION
Updated messaging to reflect expanded SimpleReport use cases

## Related Issue or Background Info

Issue #[4624](https://app.zenhub.com/workspaces/simplereport-better-data-team-605b43d51ea9f700119a48ee/issues/cdcgov/prime-simplereport/4624)

## Changes Proposed
- Removed mention of "rapid" tests
- Broadened description of user from "COVID-19 testing facilities" to "your organization"
- Included spreadsheet option in workflow description
- Changed available locations language to reflect lab users who report outside their area

## Additional Information
Discussed with and approved by Mike Judd 10/28

### Testing
- [ ] Homepage design is unchanged 
- [ ] Copy changes reflect 10/28 discussion with Mike Judd (captured in [Mural audit](https://app.mural.co/t/skylight2171/m/skylight2171/1664392557266/0018fd76899764b491e81372dd670b24a101170c?sender=ubabac35f4785db237eae9972))

**Screenshots**
![Screen Shot 2022-11-02 at 6 53 57 AM](https://user-images.githubusercontent.com/22102190/199553855-77e0b8ad-ea1c-4fdd-88d6-27de07597043.png)

![Screen Shot 2022-11-02 at 6 54 09 AM](https://user-images.githubusercontent.com/22102190/199553902-5909ee1f-0698-45f7-ad2c-9d86ee05159f.png)

![Screen Shot 2022-11-02 at 6 57 43 AM](https://user-images.githubusercontent.com/22102190/199553705-48c84a87-2029-4e2d-ba91-6a541607edba.png)

