### PR TITLE
Bump setup-node to v3 for new envs.

### DIFF
--- a/.github/workflows/deployDev5.yml
+++ b/.github/workflows/deployDev5.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
       - name: Set up Ruby

--- a/.github/workflows/deployDev6.yml
+++ b/.github/workflows/deployDev6.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
       - name: Set up Ruby

--- a/.github/workflows/deployDev7.yml
+++ b/.github/workflows/deployDev7.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
       - name: Set up Ruby


### PR DESCRIPTION
## Related Issue or Background Info
- Updates `setup-node` action for new env deployments to bring version in line with changes made while existing PR was in progress.
