### PR TITLE
fix headers and image alt text on support page

### DIFF
--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -1082,7 +1082,7 @@ Typography
 }
 
 .support-page-section-1 {
-  h1 {
+  h2 {
     font-family: Inter;
     font-style: normal;
     font-weight: 500;
@@ -1173,7 +1173,7 @@ Typography
       padding-left: 50px;
     }
 
-    h1 {
+    h2 {
       margin-top: 22px;
     }
   }
@@ -1198,7 +1198,7 @@ Typography
     height: 100%;
   }
 
-  h1 {
+  h2 {
     font-family: Inter;
     font-style: normal;
     font-weight: 500;
@@ -1245,7 +1245,7 @@ Typography
     }
   }
 
-  h1 {
+  h2 {
     margin-top: 0px;
     @include at-media("tablet") {
       margin-top: 22px;
@@ -1270,7 +1270,7 @@ Typography
   background: #97d4ea;
   padding-top: 80px;
 
-  h1 {
+  h2 {
     font-family: Inter;
     font-style: normal;
     font-weight: bold;

--- a/pages/support.html
+++ b/pages/support.html
@@ -29,12 +29,12 @@ title: Support
 </section>
 <section class="support-page-section-1">
     <div class="grid-container">
-        <h1>Get answers to common questions about SimpleReport</h1>
+        <h2>Get answers to common questions about SimpleReport</h2>
         <ul class="usa-card-group">
             <li class="tablet:grid-col-4 usa-card flex-3">
                 <div class="usa-card__container">
                     <header class="usa-card__header">
-                        <h2 class="usa-card__heading">Account management</h2>
+                        <h3 class="usa-card__heading">Account management</h3>
                     </header>
                     <div class="usa-card__body display-flex flex-column">
                         <a class="usa-link" href="/using-simplereport/reset-your-simplereport-password/">Reset your password</a>
@@ -56,7 +56,7 @@ title: Support
             <li class="tablet:grid-col-4 usa-card flex-3">
                 <div class="usa-card__container">
                     <header class="usa-card__header">
-                        <h2 class="usa-card__heading">Testing</h2>
+                        <h3 class="usa-card__heading">Testing</h3>
                     </header>
                     <div class="usa-card__body display-flex flex-column">
                         <a class="usa-link" href="/using-simplereport/conduct-and-submit-tests/">Conduct and submit tests</a>
@@ -77,7 +77,7 @@ title: Support
             <li class="tablet:grid-col-4 usa-card flex-3">
                 <div class="usa-card__container">
                     <header class="usa-card__header">
-                        <h2 class="usa-card__heading">Getting started</h2>
+                        <h3 class="usa-card__heading">Getting started</h3>
                     </header>
                     <div class="usa-card__body tall display-flex flex-column">
                         <a class="usa-link" href="/sign-up">Sign up</a>
@@ -110,14 +110,14 @@ title: Support
                 </div>
             </div>
             <div class="tablet:grid-col-5 grid-col-12">
-                <h1>SimpleReport training</h1>
+                <h2>SimpleReport training</h2>
                 <p>Video tutorials show you how to use SimpleReport.</p>
                 <a href="https://www.youtube.com/playlist?list=PL3U3nqqPGhab0sys3ombZmwOplRYlBOBF" class="usa-button usa-button--big">Watch more videos</a>
             </div>
         </div>
         <a class="training-transcript-link" target="_blank" href="/getting-started-video-transcript">
             Text transcript of the SimpleReport training video 
-            <img class="link-svg" src="/assets/uswds/img/usa-icons/launch.svg">
+            <img class="link-svg" src="/assets/uswds/img/usa-icons/launch.svg" alt="launch transcript">
         </a>
 
     </div>
@@ -126,7 +126,7 @@ title: Support
     <div class="grid-container">
         <div class="grid-row">
             <div class="tablet:grid-col-6 grid-col-12">
-                <h1>Try it out</h2>
+                <h2>Try it out</h2>
                 <p>We’ve set up sample patients and tests for you to view. Try out features and see how SimpleReport could work for you, without creating an account.</p>
                 <a href="https://training.simplereport.gov/app"
                     class="usa-button usa-button--big">Take a look around</a>
@@ -141,7 +141,7 @@ title: Support
 </section><section class="support-page-section-4">
     <div class="grid-container">
         <div class="display-flex flex-column flex-align-center">
-            <h1>Get in touch</h2>
+            <h2>Get in touch</h2>
             <p>We’re here to help.</p>
             <a href="/contact-us" class="usa-button usa-button--big">Contact us</a>
         </div>


### PR DESCRIPTION
## Related Issue or Background Info

[Related Issue](https://github.com/CDCgov/prime-simplereport/issues/4515)
- 

## Changes Proposed

- Refactor the headers on the support page to have one h1, and all other headers follow order correctly
  - repeated h1 --> h2
  - existing h2 --> h3
- Add alt text for the image used on the launch transcript link for the youtube video

## Additional Information

- I ran an axe devtools scan, and that flagged the alt text image so I opted to fix that one as well.
  ![alt text resolved](https://user-images.githubusercontent.com/89797785/203578816-385470fc-9a15-4be6-a1cd-3c254fe54234.png)
-  Note that the scan didn't flag the header issue requested to be fixed in this ticket.
- All other flagged issues were noted as "This potential issue needs your review..." and those are all either false positives or not fixable
  - use only allowed aria attributes - this is embedded by the iframe and there's nothing we can do about it
    ![aria label false positive](https://user-images.githubusercontent.com/89797785/203578176-51ffcac2-b0b3-458f-bfde-20a8f460f1c3.png)
  - video elements have captions - we add the link to transcript and youtube provides auto-generated captions
     ![iframe false positive](https://user-images.githubusercontent.com/89797785/203578404-113fffa6-ffa5-402b-865c-2e377d247c90.png)
  - links with same name must have similar purpose - and indeed they do, they go to the sign up page, so this is fine
    ![same name false positive](https://user-images.githubusercontent.com/89797785/203578561-ab682353-d6d2-42fa-a442-0403cd1e3d8a.png)

## How to Test
- Run axe and confirm headers and alt text are not flagged
- Confirm that styling looks the same on the support page

## Screenshots / Demos

**Support Page** before on top, after on bottom
- Top section and section 1
   ![top and section 1 before](https://user-images.githubusercontent.com/89797785/203580054-5d0e3ae7-2650-44f0-9f36-1a35110b8c19.png) ![top and section 1 after](https://user-images.githubusercontent.com/89797785/203580117-b5fdaecb-6df8-46a4-a09f-ba9998872f37.png)
- Section 2 and 3
   ![section 2-3 before](https://user-images.githubusercontent.com/89797785/203580188-c874f44a-a18c-432d-8821-54f928932a70.png) ![section 2-3 after](https://user-images.githubusercontent.com/89797785/203580212-b79a1609-475a-477a-b211-dea322e50e85.png)
- Section 4
   ![section 4 before](https://user-images.githubusercontent.com/89797785/203580284-8243953e-5947-40eb-b5cd-c83c1693fe79.png) ![section 4 after](https://user-images.githubusercontent.com/89797785/203580302-6450b1c7-968d-4b78-ac51-9339ae3cd39d.png)


**Axe Scans**
- Axe scan before
   ![axe before](https://user-images.githubusercontent.com/89797785/203579823-6b068b9c-051d-407c-90d9-419b8a7ef42d.png)
- Axe scan after
   ![axe after](https://user-images.githubusercontent.com/89797785/203579836-df82a784-a6f8-40b1-86ad-eb5da927f321.png)


## Checklist for Author and Reviewer

### Testing
- [x] Includes a summary of what a code reviewer should verify

### Design
- [x] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams


