### PR TITLE
Update Ruby action to avoid deprecated implementation.

### DIFF
--- a/.github/workflows/deployAzureDemo.yml
+++ b/.github/workflows/deployAzureDemo.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployDev.yml
+++ b/.github/workflows/deployDev.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployDev2.yml
+++ b/.github/workflows/deployDev2.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployDev3.yml
+++ b/.github/workflows/deployDev3.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployDev4.yml
+++ b/.github/workflows/deployDev4.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployDev5.yml
+++ b/.github/workflows/deployDev5.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployDev6.yml
+++ b/.github/workflows/deployDev6.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployDev7.yml
+++ b/.github/workflows/deployDev7.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployPentest.yml
+++ b/.github/workflows/deployPentest.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployStg.yml
+++ b/.github/workflows/deployStg.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployTest.yml
+++ b/.github/workflows/deployTest.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1

--- a/.github/workflows/deployTraining.yml
+++ b/.github/workflows/deployTraining.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "14"
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - uses: azure/login@v1


### PR DESCRIPTION
## Related Issue or Background Info

- Deploys of the static site have been failing due to an inability to find the pinned Ruby version, `2.7`. This appears to be related to our usage of a long-deprecated action version.

## Changes Proposed

- Migrate from `actions/setup-ruby@v1` to `ruby/setup-ruby@v1`.
