### PR TITLE
Update patient bulk upload guide

### DIFF
--- a/_pages/using-simplereport/manage-people-you-test/bulk-upload-patients.md
+++ b/_pages/using-simplereport/manage-people-you-test/bulk-upload-patients.md
@@ -114,7 +114,7 @@ Before you upload your spreadsheet on SimpleReport, make sure your patient data 
         <li>
           <code>ASKU</code>
           or
-          <code>Ask but unknown</code>
+          <code>Ask, but unknown</code>
         </li>
         <li>
           <code>UNK</code>

--- a/_pages/using-simplereport/manage-people-you-test/bulk-upload-patients.md
+++ b/_pages/using-simplereport/manage-people-you-test/bulk-upload-patients.md
@@ -78,7 +78,51 @@ Before you upload your spreadsheet on SimpleReport, make sure your patient data 
   <tr>
     <td style="font-weight: 600;">race</td>
     <td style="font-weight: 600;">Yes</td>
-    <td>Select from these values:<br><ul><li><code>American Indian or Alaska Native</code></li><li><code>Asian</code></li><li><code>Black or African American</code></li><li><code>Native Hawaiian or other Pacific Islander</code></li><li><code>White</code></li><li><code>Other</code></li><li><code>Unknown</code></li><li><code>Ask but unknown</code></li></ul></td>
+    <td>Select from these values:
+      <br>
+      <ul>
+        <li>
+          <code>1002-5</code>
+          or
+          <code>American Indian or Alaska Native</code>
+        </li>
+        <li>
+          <code>2028-9</code>
+          or
+          <code>Asian</code>
+        </li>
+        <li>
+          <code>2054-5</code>
+          or
+          <code>Black or African American</code>
+        </li>
+        <li>
+          <code>2076-8</code>
+          or
+          <code>Native Hawaiian or other Pacific Islander</code>
+        </li>
+        <li>
+          <code>2106-3</code>
+          or
+          <code>White</code>
+        </li>
+        <li>
+          <code>2131-1</code>
+          or
+          <code>Other</code>
+        </li>
+        <li>
+          <code>ASKU</code>
+          or
+          <code>Ask but unknown</code>
+        </li>
+        <li>
+          <code>UNK</code>
+          or
+          <code>Unknown</code>
+        </li>
+      </ul>
+    </td>
     <td></td>
   </tr>
    <tr>
@@ -90,13 +134,66 @@ Before you upload your spreadsheet on SimpleReport, make sure your patient data 
   <tr>
     <td style="font-weight: 600;">biological_sex</td>
     <td style="font-weight: 600;">Yes</td>
-    <td>Select from these values:<br><ul><li><code>Male</code></li><li><code>Female</code></li><li><code>Other</code></li><li><code>Ambiguous</code></li><li><code>Unknown</code></li><li><code>Not applicable</code></li></ul></td>
+    <td>Select from these values:
+      <br>
+      <ul>
+        <li>
+          <code>M</code>
+          or
+          <code>Male</code>
+        </li>
+        <li>
+          <code>F</code>
+          or
+          <code>Female</code>
+        </li>
+        <li>
+          <code>O</code>
+          or
+          <code>Other</code>
+        </li>
+        <li>
+          <code>U</code>
+          or
+          <code>Unknown</code>
+        </li>
+        <li>
+          <code>A</code>
+          or
+          <code>Ambiguous</code>
+        </li>
+        <li>
+          <code>N</code>
+          or
+          <code>Not applicable</code>
+        </li>
+      </ul>
+    </td>
     <td></td>
   </tr>
   <tr>
     <td style="font-weight: 600;">ethnicity</td>
     <td style="font-weight: 600;">Yes</td>
-    <td>Select from these values:<br><ul><li><code>Hispanic or Latino</code></li><li><code>Not Hispanic or Latino</code></li><li><code>Unknown</code></li></ul></td>
+    <td>Select from these values:
+      <br>
+      <ul>
+        <li>
+          <code>2135-2</code>
+          or
+          <code>Hispanic or Latino</code>
+        </li>
+        <li>
+          <code>2186-5</code>
+          or
+          <code>Not Hispanic or Latino</code>
+        </li>
+        <li>
+          <code>UNK</code>
+          or
+          <code>Unknown</code>
+        </li>
+      </ul>
+    </td>
     <td></td>
   </tr>
   <tr>
@@ -156,13 +253,51 @@ Before you upload your spreadsheet on SimpleReport, make sure your patient data 
   <tr>
     <td style="font-weight: 600;">employed_in_<br>healthcare</td>
     <td style="font-weight: 600;">Yes</td>
-    <td>Select from one of these values:<br><ul><li><code>Y</code> or <code>Yes</code></li><li><code>N</code> or <code>No</code></li><li><code>Unk</code> or <code>Unknown</code></li></ul></td>
+    <td>Select from one of these values:
+      <br>
+      <ul>
+        <li>
+          <code>Y</code>
+          or
+          <code>YES</code>
+        </li>
+        <li>
+          <code>N</code>
+          or
+          <code>NO</code>
+        </li>
+        <li>
+          <code>U</code>
+          or
+          <code>UNK</code>
+        </li>
+      </ul>
+    </td>
     <td></td>
   </tr>
   <tr>
     <td style="font-weight: 600;">resident_<br>congregate_<br>setting</td>
     <td style="font-weight: 600;">Yes</td>
-    <td>Select from one of these values:<br><ul><li><code>Y</code> or <code>Yes</code></li><li><code>N</code> or <code>No</code></li><li><code>Unk</code> or <code>Unknown</code></li></ul></td>
+    <td>Select from one of these values:
+      <br>
+      <ul>
+        <li>
+          <code>Y</code>
+          or
+          <code>YES</code>
+        </li>
+        <li>
+          <code>N</code>
+          or
+          <code>NO</code>
+        </li>
+        <li>
+          <code>U</code>
+          or
+          <code>UNK</code>
+        </li>
+      </ul>
+    </td>
     <td></td>
   </tr>
    <tr>


### PR DESCRIPTION
## Related Issue or Background Info
Resolves: [#5456](https://app.zenhub.com/workspaces/simplereport-growth--engagement-605b43a6ceb92c000f86279a/issues/gh/cdcgov/prime-simplereport/5456)

## Changes Proposed
- Update copy to include alternate values for the following:
  1. Update patient bulk upload guide on static site for Yes, No, Unknown values to accept `U` or `UNK` to match test results bulk upload
  1. Update patient bulk upload guide on static site for `biological_sex` field to also accept `M`, `F`, `O`, `U`, `A`, `N` values
  1. Update patient bulk upload guide on static site for `race` to include the test results bulk upload code values for `race` (e.g. `1002-5` `ASKU` `2028-9` etc...)
  1. Update patient bulk upload guide on static site for `patient_ethnicity` to include the test results bulk upload code values for `patient_ethnicity`(e.g. `2135-2` etc...)

Shared patient bulk upload and test results bulk upload values should now match one another. [See test results bulk upload guide](https://dev2.simplereport.gov/app/results/upload/submit/guide?facility=1a0139b9-fc23-450b-9b6c-cd081e5cea9d).

## Additional Information
<!--- decisions that were made, discussion of tradeoffs / future work, complaints about how bad the code is, etc -->

- 

## Screenshots / Demos

## Checklist for Author and Reviewer


### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- Deployed to dev2 for testing
