### PR TITLE
added usa-link class

### DIFF
--- a/pages/support.html
+++ b/pages/support.html
@@ -118,7 +118,7 @@ title: Support
                     </div>
             </div>
         </div>
-        <a class="training-transcript-link" target="_blank" href="/getting-started-video-transcript">
+        <a class="training-transcript-link usa-link" target="_blank" href="/getting-started-video-transcript">
             Text transcript of the SimpleReport training video 
         </a>
 


### PR DESCRIPTION
## Related Issue or Background Info
<!--- link to issue, or a few sentences describing why this PR exists -->

- Resolves #4122

## Changes Proposed

- I did a quick audit to all the pages in the static site and only found one link that didn't follow the required styling. 
- I added the usa-link class to the transcript link for the support page

## Screenshots / Demos
<img width="654" alt="Screenshot 2023-04-04 at 11 45 52 AM" src="https://user-images.githubusercontent.com/103958711/229846506-22f7db45-7a92-4ba9-b4c2-9e3e4a9293df.png">


## Checklist for Author and Reviewer


### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [X] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Testing
Code is deployed in dev2
Go to the support page and verify the transcript link follows the usa-link styling
