### PR TITLE
Add alt text to what's new page images

### DIFF
--- a/_includes/components/feature-card.html
+++ b/_includes/components/feature-card.html
@@ -1,6 +1,6 @@
 {% assign feature = include.feature %}
 <div class="whats-new-card">
-  <img class="whats-new-image" src="{{feature.image-path}}" />
+  <img class="whats-new-image" src="{{feature.image-path}}" alt="{{feature.image_alt || ''}}" />
   <div class="whats-new-textbox">
     <div class="whats-new-text-content">
       {% if feature.link_to_learn_more %}

--- a/_whats-new/bulk-results-uploader.md
+++ b/_whats-new/bulk-results-uploader.md
@@ -5,7 +5,8 @@ class: page-docs
 return_top: "false"
 home_link: true
 link_to_learn_more: /using-simplereport/report-test-results/bulk-upload-results/
-date: 2022-10-06 
+date: 2022-10-06
 image-path: /assets/img/resources/whats-new/bulk-results-uploader.png
+image_alt: "Reporting multiple results with a CSV bulk upload"
 blurb: In addition to submitting one test at a time, you now have the option to report multiple test results at once with a CSV file. Find the bulk results uploader and guidelines under the Results tab in SimpleReport.
 ---

--- a/_whats-new/bulk-upload-patients.md
+++ b/_whats-new/bulk-upload-patients.md
@@ -5,7 +5,8 @@ class: page-docs
 return_top: "false"
 home_link: true
 link_to_learn_more: /using-simplereport/manage-people-you-test/bulk-upload-patients/
-date: 2022-12-07 
+date: 2022-12-07
 image-path: /assets/img/resources/whats-new/patient-bulk-upload.png
+image_alt: "Import multiple patients by uploading a CSV"
 blurb: You now have the option to add patients in bulk. Follow our CSV data guidelines, then select “Import patients from spreadsheet“ to upload. As before, you can also add patients individually, or ask them to register themselves.
 ---

--- a/_whats-new/download-results.md
+++ b/_whats-new/download-results.md
@@ -7,5 +7,6 @@ home_link: true
 date: 2022-01-10
 link_to_learn_more: /using-simplereport/manage-results/download-test-results/
 image-path: /assets/img/resources/whats-new/download_results.jpg
+image_alt: "Download multiple test results"
 blurb: Admin and standard users can now download test results as a CSV file. Download all results, or filter by date, result, or role before downloading. Analyze and view results and identify trends quickly and easily.
 ---

--- a/_whats-new/entering-flu-results.md
+++ b/_whats-new/entering-flu-results.md
@@ -7,5 +7,6 @@ home_link: true
 link_to_learn_more: /using-simplereport/test-for-other-diseases/influenza/
 date: 2022-07-11
 image-path: /assets/img/resources/whats-new/multiplex_results.jpg
+image_alt: "Entering flu and COVID-19 results for a patient"
 blurb: Facilities using devices that test for both COVID-19 and flu must now enter results for both diseases into SimpleReport. Patients that test positive will get disease-specific treatment guidance with their test results.
 ---

--- a/_whats-new/send-results-over-text-or-email.md
+++ b/_whats-new/send-results-over-text-or-email.md
@@ -7,5 +7,6 @@ home_link: true
 date: 2022-01-10
 link_to_learn_more: /using-simplereport/manage-results/print-someones-test-results/
 image-path: /assets/img/resources/whats-new/send_results.jpg
+image_alt: "Selecting a test result to email to a patient"
 blurb: Send test results to patients via text or email at any time. Results can be sent to multiple phone numbers and email addresses, directly from the Results page on SimpleReport.
 ---


### PR DESCRIPTION
## Related Issue or Background Info
Resolves [#5792](https://github.com/CDCgov/prime-simplereport/issues/5792)

## Changes Proposed
Add alt text to images on the "What's new" page (`/using-simplereport/whats-new/`)

## Additional Information
N/A

## Screenshots / Demos
on dev7 for testing
https://dev7.simplereport.gov/using-simplereport/whats-new/

## Checklist for Author and Reviewer
Adding @lauraykerr in case any of the alt text copy can be improved!

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify
