### PR TITLE
Assigned reviewers for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "simplereport-staticsitereviewers"
+      - "cdcgov/simplereport-staticsitereviewers"
       - "alismx"
 
   - package-ecosystem: "npm"
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "simplereport-staticsitereviewers"
+      - "cdcgov/simplereport-staticsitereviewers"
       - "alismx"
 
   - package-ecosystem: "bundler"
@@ -26,5 +26,5 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "simplereport-staticsitereviewers"
+      - "cdcgov/simplereport-staticsitereviewers"
       - "alismx"


### PR DESCRIPTION
## Related Issue or Background Info

- reviewers are not being properly assigned; this should fix that.

Note: The `cdcgov/simplereport-staticsitereviewers` team only has 3 members. I don't have permission to add additional users.

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify
