### PR TITLE
Added unique query param to maintenance.json to bypass browser cache

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -49,7 +49,8 @@ _src %}
 <!-- Script for getting current maintenance mode status -->
 <script type="text/javascript">
   (async function getMaintenanceMode() {
-    const maintenance = await fetch("/maintenance.json");
+    const maintenanceUrl = `/maintenance.json?v=${Date.now()}`;
+    const maintenance = await fetch(maintenanceUrl);
     try {
       const maintenanceJSON = await maintenance.json();
       if (maintenanceJSON.active) {


### PR DESCRIPTION
## Related Issue or Background Info

- Partially resolves [6110](https://github.com/CDCgov/prime-simplereport/issues/6110)

## Changes Proposed

- Add a unique query string parameter to the maintenance.json url to bypass the browser cache.

## Testing
Code is available in dev4

## Screenshots / Demos
![Screenshot 2023-07-11 at 3 34 54 PM](https://github.com/CDCgov/prime-simplereport-site/assets/103958711/719087b8-0d56-483b-8511-166f3d2152b4)
