### PR TITLE
Fix newly broken links.

### DIFF
--- a/_includes/components/footer--slim.html
+++ b/_includes/components/footer--slim.html
@@ -113,7 +113,7 @@
           <a href="{% link pages/about-us.md %}">About us</a>
         </li>
         <li class="usa-identifier__required-links-item">
-          <a href="https://www.cdc.gov/contact/accessibility.html"
+          <a href="https://www.cdc.gov/other/accessibility.html"
             >Accessibility</a
           >
         </li><li class="usa-identifier__required-links-item">

--- a/_pages/getting-started/public-health-departments/simplereport-data-catalog.md
+++ b/_pages/getting-started/public-health-departments/simplereport-data-catalog.md
@@ -10,7 +10,7 @@ return_top: 'true'
 
 If you use SimpleReport, or you're a public health department receiving data from SimpleReport, here’s what you can expect. SimpleReport captures all of the data needed to meet the requirements described in the U.S. government's [COVID-19 Lab Data Reporting guidance](https://www.hhs.gov/coronavirus/testing/covid-19-diagnostic-data-reporting/index.html), including ask on order entry questions and a unique specimen ID.
 
-SimpleReport sends test results to public health departments as HL7 2.5.1 ELR (electronic lab results) through ReportStream. View the full [ReportStream documentation [GitHub]](https://github.com/CDCgov/prime-data-hub/blob/production/prime-router/docs/schema_documentation/primedatainput-pdi-covid-19.md). You can also learn more on the [ReportStream website](https://reportstream.cdc.gov/).
+SimpleReport sends test results to public health departments as HL7 2.5.1 ELR (electronic lab results) through ReportStream. View the full [ReportStream documentation [GitHub]](https://github.com/CDCgov/prime-data-hub/blob/production/prime-router/docs/docs-deprecated/schema_documentation/primedatainput-pdi-covid-19.md). You can also learn more on the [ReportStream website](https://reportstream.cdc.gov/).
 
 ## Types of data fields
 Data created in SimpleReport falls into three categories:


### PR DESCRIPTION
## Related Issue or Background Info
<!--- link to issue, or a few sentences describing why this PR exists -->

- Fixes broken links to content on redesigned CDC site.

## Changes Proposed

- Fixes broken links to content on redesigned CDC site.
- Fixes broken links to schema documentation caused by ReportStream repository rework.

## Testing

Does the `Check Link Continuity` check pass? If so, consider this tested.
