### PR TITLE
Remove faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "del": "^6.0.0",
     "eslint": "^8.46.0",
     "eslint-plugin-frontmatter": "0.0.8",
-    "faker": "^6.6.6",
     "gh-pages": "^5.0.0",
     "gulp": "^4.0.2",
     "gulp-postcss": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,11 +2046,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
-faker@^6.6.6:
-  version "6.6.6"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-6.6.6.tgz#e9529da0109dca4c7c5dbfeaadbd9234af943033"
-  integrity sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==
-
 fancy-log@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"


### PR DESCRIPTION
## Related Issue or Background Info

- resolves #582 

## Changes Proposed

- Remove faker because we aren't using it.

## Additional Information

- This version of faker is unusable. The maintainer deliberately removed the functional code from this package. This is related to the colors.js [CVE-2021-23567](https://github.com/advisories/GHSA-gh88-3pxp-6fm8).
- If we want to use faker, the functional code for this package was forked and can be found [here](https://github.com/faker-js/faker).

## Checklist for Author and Reviewer

### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify
