### PR TITLE
breadcrumb insufficient contrast

### DIFF
--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -1320,11 +1320,9 @@ Typography
 }
 
 .usa-breadcrumb__link {
-  &:visited {
-    color: #005ea2;
-  }
-  &:hover {
-    text-decoration: underline;
+  text-decoration: underline;
+
+  &:hover, &:focus {
     color: #1a4480;
   }
 }


### PR DESCRIPTION
## Related Issue or Background Info
I am currently running the axe scans on the static site and the breadcrumbs are being flagged again. This change has no ticket.

## Changes Proposed
Add underline to basic state as the color alone does not pass contrasts ratio.
Override the color set on hover and focus to make sure there is an indicator for them.

## Screenshots / Demos
![Screenshot 2023-08-17 at 9 43 55 AM](https://github.com/CDCgov/prime-simplereport-site/assets/103958711/3116599e-2236-46d1-a606-56fc1951d896)

