### PR TITLE
set aria-label for `Learn more` link to feature title

### DIFF
--- a/_includes/components/feature-card.html
+++ b/_includes/components/feature-card.html
@@ -28,6 +28,7 @@
         href="{{feature.link_to_learn_more}}"
         target="__blank"
         class="feature_url"
+        aria-label="{{feature.title}}"
       >
         Learn more
       </a>


### PR DESCRIPTION
## Related Issue or Background Info
<!--- link to issue, or a few sentences describing why this PR exists -->

- Resolves [#6442](https://github.com/CDCgov/prime-simplereport/issues/6442)
  - "Learn more" text is not descriptive on the [what's new page](https://www.dev.simplereport.gov/using-simplereport/whats-new/).
 
## Changes Proposed

- Set aria-label for the text to be the the same as the title

## Screenshots / Demos

<img width="1264" alt="image" src="https://github.com/CDCgov/prime-simplereport-site/assets/10108172/8817f453-d58f-4bf2-8d9c-a749432e9ed9">
