### PR TITLE
remove usa-skipnav from touchpoints-skipnav

### DIFF
--- a/_sass/touchpoints.scss
+++ b/_sass/touchpoints.scss
@@ -3431,7 +3431,7 @@ img {
     padding-left: 4rem;
 }
 
-#fba-modal-dialog .usa-skipnav {
+#fba-modal-dialog .touchpoints-skipnav {
     font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
     font-size: 1.06rem;
     line-height: 1.5;
@@ -3446,15 +3446,15 @@ img {
     z-index: 100;
 }
 
-#fba-modal-dialog .usa-skipnav:hover {
+#fba-modal-dialog .touchpoints-skipnav:hover {
     color: #1a4480;
 }
 
-#fba-modal-dialog .usa-skipnav:active {
+#fba-modal-dialog .touchpoints-skipnav:active {
     color: #162e51;
 }
 
-#fba-modal-dialog .usa-skipnav:focus {
+#fba-modal-dialog .touchpoints-skipnav:focus {
     outline: 0.25rem solid #2491ff;
     outline-offset: 0;
     background: white;
@@ -3464,7 +3464,7 @@ img {
     transition: 0.2s ease-in-out;
 }
 
-#fba-modal-dialog .usa-skipnav:visited {
+#fba-modal-dialog .touchpoints-skipnav:visited {
     color: #54278f;
 }
 
@@ -4263,7 +4263,7 @@ img {
     border-bottom-right-radius: 0
 }
 
-.usa-skipnav.touchpoints-skipnav {
+.touchpoints-skipnav {
     font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
     font-size: 1.06rem;
     line-height: 1.5;
@@ -4278,24 +4278,21 @@ img {
     z-index: 100;
 }
 
-.usa-skipnav.touchpoints-skipnav:hover {
+.touchpoints-skipnav:hover {
     color: #1a4480;
 }
 
-.usa-skipnav.touchpoints-skipnav:active {
+.touchpoints-skipnav:active {
     color: #162e51;
 }
 
-.usa-skipnav.touchpoints-skipnav:focus {
-    outline: 0.25rem solid #2491ff;
-    outline-offset: 0;
-}
-
-.usa-skipnav.touchpoints-skipnav:visited {
+.touchpoints-skipnav:visited {
     color: #54278f;
 }
 
-.usa-skipnav.touchpoints-skipnav:focus {
+.touchpoints-skipnav:focus {
+    outline: 0.25rem solid #2491ff;
+    outline-offset: 0;
     background: white;
     left: 0;
     position: absolute;

--- a/assets/js/sr-touchpoints.js
+++ b/assets/js/sr-touchpoints.js
@@ -68,6 +68,8 @@ function initCustomTouchpointsJS() {
   }
 
   attachModalToggleListener();
+  const feedbackSkipLink = document.querySelector(".touchpoints-skipnav");
+  feedbackSkipLink.classList.remove("usa-skipnav");
 }
 
 // need to wait for everything to load otherwise this will not work in Firefox

--- a/assets/js/touchpoints.js
+++ b/assets/js/touchpoints.js
@@ -406,7 +406,7 @@ function FBAform(d, N) {
     },
     loadFeebackSkipLink: function () {
       this.skipLink = document.createElement("a");
-      this.skipLink.setAttribute("class", "touchpoints-skipnav");
+      this.skipLink.setAttribute("class", "usa-skipnav touchpoints-skipnav");
       this.skipLink.setAttribute("href", "#fba-button");
       this.skipLink.addEventListener("click", function () {
         document.querySelector("#fba-button").focus();

--- a/assets/js/touchpoints.js
+++ b/assets/js/touchpoints.js
@@ -406,7 +406,7 @@ function FBAform(d, N) {
     },
     loadFeebackSkipLink: function () {
       this.skipLink = document.createElement("a");
-      this.skipLink.setAttribute("class", "usa-skipnav touchpoints-skipnav");
+      this.skipLink.setAttribute("class", "touchpoints-skipnav");
       this.skipLink.setAttribute("href", "#fba-button");
       this.skipLink.addEventListener("click", function () {
         document.querySelector("#fba-button").focus();


### PR DESCRIPTION
## Related Issue or Background Info
<!--- link to issue, or a few sentences describing why this PR exists -->

- Resolves [6364](https://github.com/CDCgov/prime-simplereport/issues/6364)
  - After using the skipnav for "Skip to feedback" the touchpoints button becomes inaccessible via tab.

## Changes Proposed

- Remove usa-skipnav from touchpoints skipnav 
 
## Additional Information

- [usa-skipnav](https://github.com/uswds/uswds/blob/1b88ad075a7cd3f4eab8a5828244c44995931fe9/packages/usa-skipnav/src/index.js#L18-L26) will set the tabIndex to -1 after the current object has been blured so we cannot use that.



### Testing
- Deployed to [dev1](https://dev.simplereport.gov/)
- Touchpoints is accessible
