### PR TITLE
Update data catalog ordering provider info

### DIFF
--- a/_pages/getting-started/public-health-departments/simplereport-data-catalog.md
+++ b/_pages/getting-started/public-health-departments/simplereport-data-catalog.md
@@ -110,15 +110,15 @@ The testing lab and ordering facility are the same thing in SimpleReport, so you
 {% endcapture %}
 
 {% capture ordering-provider %}
-- Ordering provider's ID (optional)
+- Ordering provider's ID (required)
   - The ordering provider's National Provider Identifier
-- Ordering provider's last name (optional)
-- Ordering provider's first name (optional)
-- Ordering provider's street address (optional)
-- Ordering provider's city (optional)
-- Ordering provider's state (optional)
-- Ordering provider's zip code (optional)
-- Ordering provider's phone number (optional)
+- Ordering provider's last name (required)
+- Ordering provider's first name (required)
+- Ordering provider's street address (required)
+- Ordering provider's city (required)
+- Ordering provider's state (required)
+- Ordering provider's zip code (required)
+- Ordering provider's phone number (required)
 - Ordering provider's county (optional)
 {% endcapture %}
 


### PR DESCRIPTION
## Related Issue or Background Info
- Resolves [#7365](https://github.com/CDCgov/prime-simplereport/issues/7365)

## Changes Proposed
- Update ordering provider details in the data catalog to "(required)" from "(optional)" where appropriate

## Additional Information
- Leaving ordering provider county as "optional" since we don't collect it in the facility form and we don't ask for it on bulk upload
- deployed on dev3: https://dev3.simplereport.gov/getting-started/public-health-departments/simplereport-data-catalog/

## Screenshots / Demos
<img width="1624" alt="Screenshot 2024-06-24 at 12 25 01" src="https://github.com/CDCgov/prime-simplereport-site/assets/20211771/2e8713e2-62cb-4564-9817-fe3460326ced">

## Checklist for Author and Reviewer


### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify
