### PR TITLE
Static Site: Hide HIV webpage from "Test for other diseases" subsection

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,9 @@ pagination:
   sort_field: "date"
   sort_reverse: true
 
+flags:
+  show_hiv_page: &show_hiv_page false
+
 defaults:
   - scope:
       path: "assets/**"
@@ -50,6 +53,10 @@ defaults:
       path: "assets/resources/Bulk_person_upload_guide.pdf"
     values:
       sitemap: true
+  - scope:
+      path: "_pages/using-simplereport/test-for-other-diseases/hiv.md"
+    values:
+      published: *show_hiv_page
 
 content:
   supported_diseases:

--- a/_includes/sidenav-custom.html
+++ b/_includes/sidenav-custom.html
@@ -21,12 +21,14 @@
               {% if entry.subsubnav[0] and page.url contains title_slug %}
                 <ul class="usa-sidenav__sublist">
                 {% for subentry in entry.subsubnav %}
-                  <li class="usa-sidenav__item">
-                    <a href="{{ site.baseurl }}{{ subentry.url }}"
-                      {% if subentry.url == page.url %} class="usa-current" {% endif %}>
-                      {{ subentry.page }}
-                    </a>
-                  </li>
+                  {% if subentry.page != 'HIV' or site.flags.show_hiv_page %}
+                    <li class="usa-sidenav__item">
+                      <a href="{{ site.baseurl }}{{ subentry.url }}"
+                        {% if subentry.url == page.url %} class="usa-current" {% endif %}>
+                        {{ subentry.page }}
+                      </a>
+                    </li>
+                  {% endif %}
                 {% endfor %}
                 </ul>
               {% endif %}


### PR DESCRIPTION
## Related Issue or Background Info
[Static Site: Hide HIV webpage from "Test for other diseases" subsection](https://github.com/CDCgov/prime-simplereport/issues/8528)

## Changes Proposed

* Add `flags` property to `_config.yml` which can be accessed in Liquid templates via `site.flags.[FLAG_NAME]`
* Set default `published` attribute for the `hiv.md` page in `_config.yml`.
* Modify `sidenav-custom.html` to conditionally render subsubnav items depending on the `show_hiv_page` flag.


## Additional Information

The tradeoff of this approach is having to define both the `flags` property in the Jekyll config, + adding the `published` attribute in the site config.

To override the config for different environments, we would have to add to their respective config file. For example:

```
# _dev6_config.yml
flags:
  show_hiv_page: &show_hiv_page true

defaults:
  - scope:
      path: "_pages/using-simplereport/test-for-other-diseases/hiv.md"
    values:
      published: *show_hiv_page
```

## Screenshots / Demos

URL for HIV page returns 404:
![image](https://github.com/user-attachments/assets/10580c01-eea9-4612-aca7-3c8565fb9c96)

HIV option is absent from sidebar:
![image](https://github.com/user-attachments/assets/20547b9a-9435-4a82-b069-fce3f5e4124c)


## Checklist for Author and Reviewer


### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify
