### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the team on this line will be requested for
+# review when someone opens a pull request.
+*                   @CDCgov/simplereport-engineeringreviews
+
+# github-actions
+workflows/*         @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+
+# npm
+package.json        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+yarn.lock           @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+
+# bundler
+Gemfile             @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops
+Gemfile.lock        @CDCgov/simplereport-dependencyreviews @CDCgov/simplereport-devsecops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-
 version: 2
 updates:
 
@@ -7,24 +6,15 @@ updates:
     open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "npm"
     directory: "/"
     open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"
 
   - package-ecosystem: "bundler"
     directory: "/"
     open-pull-requests-limit: 2
     schedule:
       interval: "weekly"
-    reviewers:
-      - "cdcgov/simplereport-devsecops"
-      - "cdcgov/simplereport-engineeringreviews"


### PR DESCRIPTION
## Related Issue or Background Info
Dependabot is deprecating the reviewers option so we are going to use `CODEOWNERS` instead. See PR for the app repo: https://github.com/CDCgov/prime-simplereport/pull/8857 