### PR TITLE
Add Gov Shutdown Warning

### DIFF
--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -42,4 +42,9 @@
       </div>
     </div>
   </div>
+  <div class="usa-alert usa-alert--warning" style="margin-top: unset !important;">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">During the government shutdown, only websites supporting excepted functions will be updated. As a result, the information on this website may not be up to date and the agency may not be able to respond to inquiries. Updates regarding government operating status and resumption of normal operations can be found at <a href="https://www.opm.gov/">https://www.opm.gov/</a></p>
+    </div>
+  </div>
 </section>


### PR DESCRIPTION
## Related Issue or Background Info
<!--- link to issue, or a few sentences describing why this PR exists -->

- This adds a warning banner to the static site during the government shutdown (Oct 1, 2025).

## Changes Proposed

- Add banner in banner partial.

## Additional Information
<!--- decisions that were made, discussion of tradeoffs / future work, complaints about how bad the code is, etc -->

- N/A

## Screenshots / Demos

Deployed to dev2: https://dev2.simplereport.gov/

## Checklist for Author and Reviewer


### Design
- [ ] Any UI/UX changes have a designer as a reviewer, and changes have been approved
- [ ] Any large-scale changes have been deployed to `test`, `dev`, or `pentest` and smoke-tested by both the engineering and design teams

### Content
- [ ] Any content changes (including new error messages) have been approved by content team

### Support
- [ ] Any changes that might generate new support requests have been flagged to the support team

### Testing
- [ ] Includes a summary of what a code reviewer should verify
